### PR TITLE
[#29] Style the chatbot area

### DIFF
--- a/assets/css/components/chat-container.css
+++ b/assets/css/components/chat-container.css
@@ -11,7 +11,7 @@
     }
 
     a {
-      @apply underline text-violet-900;
+      @apply underline text-violet-900 dark:text-violet-300;
     }
   }
 }

--- a/lib/exmeralda_web/live/chat_live/chat.ex
+++ b/lib/exmeralda_web/live/chat_live/chat.ex
@@ -133,7 +133,7 @@ defmodule ExmeraldaWeb.ChatLive.Chat do
       <.form for={@form} phx-target={@myself} phx-submit="send" class="flex shrink-0">
         <input type="hidden" name={@form[:index].name} value={@index + 1} />
         <input
-          class="input grow w-auto py-4 h-auto rounded-none border-x-0 border-b-0 text-lg border-t-2"
+          class="input grow w-auto py-4 h-auto rounded-none border-x-0 border-b-0 text-lg border-t-2 dark:border-gray-700"
           name={@form[:content].name}
           placeholder={gettext("What can I help you with?")}
         />
@@ -152,8 +152,8 @@ defmodule ExmeraldaWeb.ChatLive.Chat do
   def message_class(:user), do: "chat chat-end"
   def message_class(:assistant), do: "chat chat-start"
 
-  def message_content_class(:user), do: "chat-bubble bg-violet-100"
-  def message_content_class(:assistant), do: "chat-bubble bg-base-200"
+  def message_content_class(:user), do: "chat-bubble bg-violet-100 dark:bg-violet-900"
+  def message_content_class(:assistant), do: "chat-bubble bg-base-200 dark:bg-base-300"
 
   def message_role(:user), do: gettext("You")
   def message_role(:assistant), do: gettext("Assistant")


### PR DESCRIPTION
## Changes

Some cosmetic changes to the chat area:

- space between chat bubbles
- user is on right, bot on left
- colors in light and dark modes
- chat bubble less wide
- bot content has some more styles: code is more readable, links are visible

## Looks like

<img width="1719" alt="Screenshot 2025-04-02 at 16 29 13" src="https://github.com/user-attachments/assets/4525deeb-61ad-479e-92f9-0465b81a8012" />

<img width="1719" alt="Screenshot 2025-04-02 at 16 29 22" src="https://github.com/user-attachments/assets/65499c46-3a02-49ca-a1e8-5948076fa867" />
