### PR TITLE
[#EX-34] Use a less intelligent LLM (

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -65,7 +65,7 @@ cond do
            LangChain.ChatModels.ChatOpenAI.new!(%{
              endpoint: "https://api.groq.com/openai/v1/chat/completions",
              api_key: System.fetch_env!("GROQ_API_KEY"),
-             model: "qwen-2.5-coder-32b",
+             model: "llama-3.3-70b-specdec",
              stream: true
            })
 


### PR DESCRIPTION
We are currently using `qwen-2.5-coder-32b`, which is quiet an intelligent model, however, it looks like it is a bit too intelligent for our use case. llama3.2-latest seems to make a much better job.&#x20;

Let’s try:

- `llama-3.3-70b-specdec` (ok, that’s quiet a monster)
- `gemma2-9b-it`
- `llama-3.2-3b-preview`

https://bitcrowd.atlassian.net/browse/EX-34