### PR TITLE
[#EX-47] KeyError happened in…

### DIFF
--- a/lib/exmeralda_web/live/chat_live/index.ex
+++ b/lib/exmeralda_web/live/chat_live/index.ex
@@ -54,7 +54,7 @@ defmodule ExmeraldaWeb.ChatLive.Index do
 
     socket = stream_delete(socket, :sessions, session)
 
-    if session.id == socket.assigns.current_session.id do
+    if socket.assigns.current_session && session.id == socket.assigns.current_session.id do
       {:noreply, push_navigate(socket, to: ~p"/chat/start")}
     else
       {:noreply, socket}


### PR DESCRIPTION
…ExmeraldaWeb.ChatLive.Index#handle_event

## Message

    ** (KeyError) key :id not found in: nil

    If you are using the dot syntax, such as map.field, make sure the left-hand side of the dot is a map

## Backtrace (last 10 lines)

    lib/exmeralda_web/live/chat_live/index.ex:57 ExmeraldaWeb.ChatLive.Index.handle_event/3
    lib/phoenix_live_view/channel.ex:508 anonymous fn/3 in Phoenix.LiveView.Channel.view_handle_event/3
    /app/deps/telemetry/src/telemetry.erl:324 :telemetry.span/3
    lib/phoenix_live_view/channel.ex:260 Phoenix.LiveView.Channel.handle_info/2
    gen_server.erl:2345 :gen_server.try_handle_info/3
    gen_server.erl:2433 :gen_server.handle_msg/6
    proc_lib.erl:329 :proc_lib.init_p_do_apply/3

View on AppSignal:
<https://appsignal.com/bitcrowd-2/sites/67efc82bec2e1f1dc25b314c/exceptions/incidents/22>

https://bitcrowd.atlassian.net/browse/EX-47