### PR TITLE
[#EX-19] Show & link code

### DIFF
--- a/config/oban.exs
+++ b/config/oban.exs
@@ -4,7 +4,11 @@ config :exmeralda, Oban,
   engine: Oban.Engines.Basic,
   queues: [ingest: 10, query: 20],
   repo: Exmeralda.Repo,
-  plugins: [{Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 7}]
+  plugins: [
+    {Oban.Plugins.Pruner, max_age: 60 * 60 * 24 * 7},
+    Oban.Plugins.Lifeline,
+    Oban.Plugins.Reindexer
+  ]
 
 if config_env() == :test do
   config :exmeralda, Oban, testing: :manual

--- a/lib/exmeralda_web/live/chat_live/chat.ex
+++ b/lib/exmeralda_web/live/chat_live/chat.ex
@@ -107,20 +107,31 @@ defmodule ExmeraldaWeb.ChatLive.Chat do
               class="mt-3 mb-1"
             >
               <summary>{gettext("Sources")}</summary>
-              <ul class="list-disc mx-5">
-                <li :for={{source, chunks} <- message.source_chunks |> Enum.group_by(& &1.source)}>
+              <ul class="menu">
+                <li
+                  :for={{source, chunks} <- message.source_chunks |> Enum.group_by(& &1.source)}
+                  class="mb-0"
+                >
                   <% type = List.first(chunks).type %>
                   <a
                     :if={type == :docs}
                     href={"https://hexdocs.pm/#{@session.library.name}/#{@session.library.version}/#{source}"}
                     target="blank"
-                    class="link"
                     rel="noopener noreferrer"
                   >
+                    <.icon name="hero-book-open" />
                     {source}
                   </a>
 
-                  <code :if={type == :code}>{source}</code>
+                  <a
+                    :if={type == :code}
+                    href={"https://preview.hex.pm/preview/#{@session.library.name}/#{@session.library.version}/show/#{source}"}
+                    target="blank"
+                    rel="noopener noreferrer"
+                  >
+                    <.icon name="hero-code-bracket" />
+                    {source}
+                  </a>
                 </li>
               </ul>
             </details>


### PR DESCRIPTION
Currently only docs are linked. It would be awesome to link the code as well maybe ideally line numbers

https://bitcrowd.atlassian.net/browse/EX-19

![Screenshot 2025-04-07 at 12 18 52](https://github.com/user-attachments/assets/b5241e0b-47fe-4d7c-87f7-442de69890c7)
