### PR TITLE
[#EX-52] KeyError happened in…  

### DIFF
--- a/lib/exmeralda_web/controllers/auth_controller.ex
+++ b/lib/exmeralda_web/controllers/auth_controller.ex
@@ -16,7 +16,9 @@ defmodule ExmeraldaWeb.AuthController do
   end
 
   def callback(conn, params) do
-    session_params = get_session(conn, :session_params)
+    session_params =
+      get_session(conn, :session_params)
+      |> Map.new(fn {k, v} -> {String.to_existing_atom(k), v} end)
 
     config =
       conn

--- a/lib/exmeralda_web/github_mock.ex
+++ b/lib/exmeralda_web/github_mock.ex
@@ -16,7 +16,7 @@ defmodule ExmeraldaWeb.GithubMock do
 
   @impl true
   def callback(config, %{"code" => "mock_code"}) do
-    %{"state" => "mock_state"} = config[:session_params]
+    %{state: "mock_state"} = config[:session_params]
 
     user_info = %{
       "sub" => "123",


### PR DESCRIPTION
…ExmeraldaWeb.AuthController#callback   ## Message      ** (KeyError) key :state not found in: nil      If you are using the dot syntax, such as map.field, make sure the left-hand side of the dot is a map  ## Backtrace (last 10 lines)      lib/assent/strategies/oauth2.ex:217 Assent.Strategy.OAuth2.verify_state/3     lib/assent/strategies/oauth2.ex:197 Assent.Strategy.OAuth2.callback/3     lib/assent/strategies/oauth2/base.ex:74 Assent.Strategy.OAuth2.Base.callback/3     lib/exmeralda_web/controllers/auth_controller.ex:26 ExmeraldaWeb.AuthController.callback/2     lib/exmeralda_web/controllers/auth_controller.ex:1 ExmeraldaWeb.AuthController.action/2     lib/exmeralda_web/controllers/auth_controller.ex:1 ExmeraldaWeb.AuthController.phoenix_controller_pipeline/2     lib/phoenix/router.ex:484 Phoenix.Router.__call__/5     lib/exmeralda_web/endpoint.ex:1 ExmeraldaWeb.Endpoint.plug_builder_call/2  View on AppSignal: <https://appsignal.com/bitcrowd-2/sites/67efc82bec2e1f1dc25b314c/exceptions/incidents/53>  https://bitcrowd.atlassian.net/browse/EX-52