### PR TITLE
[#EX-53] User without fullname

### DIFF
--- a/lib/exmeralda_web/controllers/auth_controller.ex
+++ b/lib/exmeralda_web/controllers/auth_controller.ex
@@ -37,7 +37,7 @@ defmodule ExmeraldaWeb.AuthController do
              github_id: user["sub"],
              github_profile: user["profile"],
              email: user["email"],
-             name: user["name"],
+             name: user["name"] || user["preferred_username"] || "Anonymous",
              avatar_url: user["picture"]
            }) do
       conn


### PR DESCRIPTION
There are users in github that you don’t get a fullname from

https://bitcrowd.atlassian.net/browse/EX-53