### PR TITLE
[#EX-56] Qwen Coder discontinued

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -65,7 +65,7 @@ cond do
            LangChain.ChatModels.ChatOpenAI.new!(%{
              endpoint: "https://api.groq.com/openai/v1/chat/completions",
              api_key: System.fetch_env!("GROQ_API_KEY"),
-             model: "qwen-2.5-coder-32b",
+             model: "meta-llama/llama-4-maverick-17b-128e-instruct",
              stream: true
            })
 


### PR DESCRIPTION
Since 16:00 today, we are getting:\

    {
      "request_id": "req_01jrxjvtw2etc9agst0q7qsy6r",
      "created_at": "2025-04-15T20:39:47.330Z",
      "error": {
        "message": "The model `qwen-2.5-coder-32b` has been decommissioned and is no longer supported. Please refer to https://console.groq.com/docs/deprecations for a recommendation on which model to use instead.",
        "type": "invalid_request_error",
        "code": "model_decommissioned"
      }
    }

<!-- media: file 9bcff0f1-832e-414d-8412-44e605dcd4f1 -->

Let’s try `meta-llama/llama-4-maverick-17b-128e-instruct.`

With the ecto question from Mihai, it kind of worked ok:

https://bitcrowd.atlassian.net/browse/EX-56