### PR TITLE
allow library names that have two characters

### DIFF
--- a/lib/exmeralda/topics/library.ex
+++ b/lib/exmeralda/topics/library.ex
@@ -24,7 +24,7 @@ defmodule Exmeralda.Topics.Library do
     library
     |> cast(attrs, [:name, :version])
     |> validate_required([:name, :version])
-    |> validate_format(:name, ~r/^[a-z][a-z0-9_]{1,}[a-z0-9]$/)
+    |> validate_format(:name, ~r/^[a-z][a-z0-9_]*?[a-z0-9]$/)
     |> validate_version()
     |> cast_embed(:dependencies)
     |> unique_constraint([:name, :version])

--- a/test/exmeralda/topics/library_test.exs
+++ b/test/exmeralda/topics/library_test.exs
@@ -44,11 +44,11 @@ defmodule Exmeralda.Topics.LibraryTest do
     end
 
     test "validates names" do
-      for name <- ~w(ecto phoenix_live_view absinthe_graphql my_lib123) do
+      for name <- ~w(ecto phoenix_live_view absinthe_graphql my_lib123 nx) do
         assert Library.changeset(%Library{}, %{name: name, version: "1.0.0"}).valid?
       end
 
-      for name <- ~w(_underscore_start 123numbersfirst sh ends_with_ NOTEVENANAME $!@#) do
+      for name <- ~w(_underscore_start 123numbersfirst s ends_with_ NOTEVENANAME $!@#) do
         cs = Library.changeset(%Library{}, %{name: name, version: "1.0.0"})
         refute cs.valid?
         assert_error_on(cs, :name, :format)


### PR DESCRIPTION
I wanted to add [`nx`](https://hex.pm/packages/nx) but was getting an error because the name must be at least 3 characters long.

![CleanShot 2025-04-20 at 18 09 07@2x](https://github.com/user-attachments/assets/fc886922-dc0c-4990-8898-880629be88f2)

This changes the format regex and adjusts the tests accordingly.