### PR TITLE
[#EX-57] Create ingestions model

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,11 @@ Be aware that the seeded libraries are not that useful to chat with, since it is
 
 Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
 
+## Migrations
+
+We run migrations automatically when deploying the application to fly.
+
+### Data Migrations
+
+Following the [Safe Ecto Migrations](https://fly.io/phoenix-files/safe-ecto-migrations/) guide from fly, data migrations are stored separately in `priv/repo/data_migrations`.
+We must run them manually, for instance using `./exmeralda eval Exmeralda.Release.migrate_data`.

--- a/lib/exmeralda/release.ex
+++ b/lib/exmeralda/release.ex
@@ -13,6 +13,17 @@ defmodule Exmeralda.Release do
     end
   end
 
+  @doc """
+  Migrate data in the database. Defaults to migrating to the latest, `[all: true]`
+  Also accepts `[step: 1]`, or `[to: 20200118045751]`
+  """
+  def migrate_data(opts \\ [all: true]) do
+    for repo <- repos() do
+      path = Ecto.Migrator.migrations_path(repo, "data_migrations")
+      {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, path, :up, opts))
+    end
+  end
+
   def rollback(repo, version) do
     load_app()
     {:ok, _, _} = Ecto.Migrator.with_repo(repo, &Ecto.Migrator.run(&1, :down, to: version))

--- a/lib/exmeralda/topics.ex
+++ b/lib/exmeralda/topics.ex
@@ -1,6 +1,6 @@
 defmodule Exmeralda.Topics do
   alias Exmeralda.Repo
-  alias Exmeralda.Topics.{IngestLibraryWorker, Library, Chunk}
+  alias Exmeralda.Topics.{IngestLibraryWorker, Library, Chunk, Ingestion}
   import Ecto.Query
 
   def list_libraries(params) do
@@ -127,5 +127,13 @@ defmodule Exmeralda.Topics do
   """
   def new_library_changeset(params \\ %{}) do
     Library.changeset(%Library{}, params)
+  end
+
+  @doc """
+  Updates the state of an ingestion.
+  """
+  def update_ingestion_state!(ingestion, state) do
+    Ingestion.set_state(ingestion, state)
+    |> Repo.update!()
   end
 end

--- a/lib/exmeralda/topics/chunk.ex
+++ b/lib/exmeralda/topics/chunk.ex
@@ -2,6 +2,7 @@ defmodule Exmeralda.Topics.Chunk do
   use Exmeralda.Schema
 
   alias Exmeralda.Topics.Library
+  alias Exmeralda.Topics.Ingestion
 
   @derive {Flop.Schema,
            filterable: [:type, :source],
@@ -15,6 +16,7 @@ defmodule Exmeralda.Topics.Chunk do
     field :content, :string
     field(:embedding, Pgvector.Ecto.Vector)
     belongs_to(:library, Library)
+    belongs_to(:ingestion, Ingestion)
   end
 
   def set_embedding(chunk, embedding) do

--- a/lib/exmeralda/topics/generate_embeddings_worker.ex
+++ b/lib/exmeralda/topics/generate_embeddings_worker.ex
@@ -2,29 +2,41 @@ defmodule Exmeralda.Topics.GenerateEmbeddingsWorker do
   use Oban.Worker, queue: :ingest, max_attempts: 20
 
   alias Exmeralda.Repo
-  alias Exmeralda.Topics.{Chunk, Rag}
+  alias Exmeralda.Topics
+  alias Exmeralda.Topics.{Chunk, Ingestion, Rag}
 
   import Ecto.Query
 
   @embeddings_batch_size 20
   @impl Oban.Worker
-  def perform(%Oban.Job{args: %{"library_id" => id}}) do
+  def perform(%Oban.Job{args: %{"library_id" => id, "ingestion_id" => ingestion_id}}) do
     from(c in Chunk, where: c.library_id == ^id, select: c.id)
     |> Repo.all()
     |> Enum.chunk_every(@embeddings_batch_size)
-    |> Enum.map(&__MODULE__.new(%{chunk_ids: &1}))
+    |> Enum.map(&__MODULE__.new(%{chunk_ids: &1, ingestion_id: ingestion_id}))
     |> Oban.insert_all()
 
     :ok
   end
 
-  def perform(%Oban.Job{args: %{"chunk_ids" => ids}}) do
+  def perform(%Oban.Job{args: %{"chunk_ids" => ids, "ingestion_id" => ingestion_id}}) do
     from(c in Chunk, where: c.id in ^ids)
     |> Repo.all()
     |> Rag.generate_embeddings()
     |> Enum.map(&Chunk.set_embedding(Map.put(&1, :embedding, nil), &1.embedding))
     |> Enum.each(&Repo.update!/1)
 
+    if all_chunks_embedded?(ingestion_id) do
+      Repo.get!(Ingestion, ingestion_id)
+      |> Topics.update_ingestion_state!(:ready)
+    end
+
     :ok
+  end
+
+  defp all_chunks_embedded?(ingestion_id) do
+    query = from(c in Chunk, where: c.ingestion_id == ^ingestion_id and is_nil(c.embedding))
+
+    not Repo.exists?(query)
   end
 end

--- a/lib/exmeralda/topics/ingest_library_worker.ex
+++ b/lib/exmeralda/topics/ingest_library_worker.ex
@@ -2,7 +2,7 @@ defmodule Exmeralda.Topics.IngestLibraryWorker do
   use Oban.Worker, queue: :ingest, max_attempts: 20, unique: [period: {360, :minutes}]
 
   alias Exmeralda.Repo
-  alias Exmeralda.Topics.{Chunk, Library, Rag, GenerateEmbeddingsWorker}
+  alias Exmeralda.Topics.{Chunk, Ingestion, Library, Rag, GenerateEmbeddingsWorker}
   alias Ecto.Multi
   import Ecto.Query
 
@@ -27,13 +27,20 @@ defmodule Exmeralda.Topics.IngestLibraryWorker do
 
   def ingest(multi) do
     multi
+    |> Multi.run(:insert_ingestion, fn repo, %{library: library} ->
+      repo.insert(Ingestion.changeset(%{state: :embedding, library_id: library.id}))
+    end)
     |> Multi.run(:ingestion, fn _, %{library: library} ->
       Rag.ingest_from_hex(library.name, library.version)
     end)
     |> Multi.update(:dependencies, fn %{library: library, ingestion: {_, dependencies}} ->
       Library.changeset(library, %{dependencies: dependencies})
     end)
-    |> Ecto.Multi.merge(fn %{ingestion: {chunks, _}, library: library} ->
+    |> Ecto.Multi.merge(fn %{
+                             ingestion: {chunks, _},
+                             insert_ingestion: ingestion,
+                             library: library
+                           } ->
       chunks
       |> Enum.chunk_every(@insert_batch_size)
       |> Enum.with_index()
@@ -42,7 +49,7 @@ defmodule Exmeralda.Topics.IngestLibraryWorker do
           multi,
           :"chunks_#{index}",
           Chunk,
-          Enum.map(batch, &Map.put(&1, :library_id, library.id))
+          Enum.map(batch, &Map.merge(&1, %{ingestion_id: ingestion.id, library_id: library.id}))
         )
       end)
     end)

--- a/lib/exmeralda/topics/ingest_library_worker.ex
+++ b/lib/exmeralda/topics/ingest_library_worker.ex
@@ -53,8 +53,8 @@ defmodule Exmeralda.Topics.IngestLibraryWorker do
         )
       end)
     end)
-    |> Oban.insert(:generate_embeddings, fn %{library: library} ->
-      GenerateEmbeddingsWorker.new(%{library_id: library.id})
+    |> Oban.insert(:generate_embeddings, fn %{library: library, insert_ingestion: ingestion} ->
+      GenerateEmbeddingsWorker.new(%{library_id: library.id, ingestion_id: ingestion.id})
     end)
     |> Repo.transaction(timeout: 1000 * 60 * 60)
     |> case do

--- a/lib/exmeralda/topics/ingestion.ex
+++ b/lib/exmeralda/topics/ingestion.ex
@@ -1,0 +1,23 @@
+defmodule Exmeralda.Topics.Ingestion do
+  use Exmeralda.Schema
+
+  alias Exmeralda.Topics.Chunk
+  alias Exmeralda.Topics.Library
+
+  schema "ingestions" do
+    field :state, Ecto.Enum,
+      values: [:queued, :preprocessing, :chunking, :embedding, :failed, :ready]
+
+    belongs_to :library, Library
+    has_many :chunks, Chunk
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(ingestion \\ %__MODULE__{}, attrs) do
+    ingestion
+    |> cast(attrs, [:state, :library_id])
+    |> validate_required([:state, :library_id])
+  end
+end

--- a/lib/exmeralda/topics/ingestion.ex
+++ b/lib/exmeralda/topics/ingestion.ex
@@ -20,4 +20,9 @@ defmodule Exmeralda.Topics.Ingestion do
     |> cast(attrs, [:state, :library_id])
     |> validate_required([:state, :library_id])
   end
+
+  @doc false
+  def set_state(ingestion, state) do
+    change(ingestion, state: state)
+  end
 end

--- a/lib/exmeralda/topics/library.ex
+++ b/lib/exmeralda/topics/library.ex
@@ -1,7 +1,7 @@
 defmodule Exmeralda.Topics.Library do
   use Exmeralda.Schema
 
-  alias Exmeralda.Topics.{Dependency, Chunk}
+  alias Exmeralda.Topics.{Dependency, Chunk, Ingestion}
 
   @derive {Flop.Schema,
            filterable: [:name, :version],
@@ -15,6 +15,7 @@ defmodule Exmeralda.Topics.Library do
     embeds_many :dependencies, Dependency, on_replace: :delete
 
     has_many :chunks, Chunk
+    has_many :ingestions, Ingestion
 
     timestamps()
   end

--- a/priv/repo/data_migrations/20250722143354_insert_ingestions_for_libraries_and_associate_chunks.exs
+++ b/priv/repo/data_migrations/20250722143354_insert_ingestions_for_libraries_and_associate_chunks.exs
@@ -1,0 +1,42 @@
+defmodule Exmeralda.Repo.Migrations.InsertIngestionsForLibrariesAndAssociateChunks do
+  use Ecto.Migration
+  import Ecto.Query
+
+  def up do
+    libraries_ids =
+      repo().all(
+        from l in "libraries",
+          left_join: i in "ingestions",
+          on: i.library_id == l.id,
+          where: is_nil(i.library_id),
+          select: l.id
+      )
+
+    ingestions =
+      Enum.map(libraries_ids, fn library_id ->
+        %{
+          id: Ecto.UUID.bingenerate(),
+          state: "ready",
+          library_id: library_id,
+          inserted_at: DateTime.utc_now(),
+          updated_at: DateTime.utc_now()
+        }
+      end)
+
+    repo().insert_all("ingestions", ingestions)
+
+    flush()
+
+    execute("""
+    UPDATE chunks
+    SET ingestion_id = ingestions.id
+    FROM
+    ingestions
+    WHERE
+    chunks.ingestion_id IS NULL
+    AND chunks.library_id = ingestions.library_id;
+    """)
+  end
+
+  def down, do: :ok
+end

--- a/priv/repo/migrations/20250722071156_create_ingestions.exs
+++ b/priv/repo/migrations/20250722071156_create_ingestions.exs
@@ -1,0 +1,22 @@
+defmodule Exmeralda.Repo.Migrations.CreateIngestions do
+  use Ecto.Migration
+
+  def up do
+    execute(
+      "CREATE TYPE ingestion_state AS ENUM ('queued', 'preprocessing', 'chunking', 'embedding', 'failed', 'ready');"
+    )
+
+    create table(:ingestions) do
+      add :state, :ingestion_state, null: false
+      add :library_id, references(:libraries, on_delete: :delete_all), null: false
+
+      timestamps()
+    end
+  end
+
+  def down do
+    drop table(:ingestions)
+
+    execute("DROP TYPE ingestion_state;")
+  end
+end

--- a/priv/repo/migrations/20250722103839_add_ingestion_id_to_chunks.exs
+++ b/priv/repo/migrations/20250722103839_add_ingestion_id_to_chunks.exs
@@ -1,0 +1,15 @@
+defmodule Exmeralda.Repo.Migrations.AddIngestionIdToChunks do
+  use Ecto.Migration
+
+  def up do
+    alter table(:chunks) do
+      add :ingestion_id, references(:ingestions, on_delete: :delete_all), null: true
+    end
+  end
+
+  def down do
+    alter table(:chunks) do
+      remove :ingestion_id
+    end
+  end
+end

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -36,5 +36,6 @@ libraries = [
 ]
 
 for library <- libraries do
-  insert(:chunk, library: library)
+  ingestion = insert(:ingestion, library: library)
+  insert(:chunk, library: library, ingestion: ingestion)
 end

--- a/test/exmeralda/topics/generate_embeddings_worker_test.exs
+++ b/test/exmeralda/topics/generate_embeddings_worker_test.exs
@@ -7,7 +7,8 @@ defmodule Exmeralda.Topics.GenerateEmbeddingsWorkerTest do
 
   def insert_library(_) do
     library = insert(:library)
-    chunks = insert_list(25, :chunk, library: library, embedding: nil)
+    ingestion = insert(:ingestion, library: library)
+    chunks = insert_list(25, :chunk, ingestion: ingestion, library: library, embedding: nil)
     %{chunks: chunks, library: library}
   end
 

--- a/test/exmeralda/topics/ingestion_test.exs
+++ b/test/exmeralda/topics/ingestion_test.exs
@@ -1,0 +1,15 @@
+defmodule Exmeralda.Topics.IngestionTest do
+  use Exmeralda.DataCase
+
+  import BitcrowdEcto.Random
+
+  alias Exmeralda.Topics.Ingestion
+
+  describe "changeset/2" do
+    test "works" do
+      changeset = Ingestion.changeset(%{state: :queued, library_id: uuid()})
+
+      assert changeset.valid?
+    end
+  end
+end

--- a/test/exmeralda/topics/ingestion_test.exs
+++ b/test/exmeralda/topics/ingestion_test.exs
@@ -2,6 +2,7 @@ defmodule Exmeralda.Topics.IngestionTest do
   use Exmeralda.DataCase
 
   import BitcrowdEcto.Random
+  import Ecto.Changeset
 
   alias Exmeralda.Topics.Ingestion
 
@@ -10,6 +11,17 @@ defmodule Exmeralda.Topics.IngestionTest do
       changeset = Ingestion.changeset(%{state: :queued, library_id: uuid()})
 
       assert changeset.valid?
+    end
+  end
+
+  describe "set_state/2" do
+    test "sets state of ingestion" do
+      ingestion = %Ingestion{library_id: uuid(), state: :queued}
+
+      changeset = Ingestion.set_state(ingestion, :ready)
+
+      assert changeset.valid?
+      assert get_change(changeset, :state) == :ready
     end
   end
 end

--- a/test/exmeralda/topics_test.exs
+++ b/test/exmeralda/topics_test.exs
@@ -6,14 +6,16 @@ defmodule Exmeralda.TopicsTest do
 
   def insert_ingested_library(_) do
     library = insert(:library, name: "ecto")
-    insert_list(3, :chunk, library: library)
+    ingestion = insert(:ingestion, library: library)
+    insert_list(3, :chunk, ingestion: ingestion, library: library)
     %{ingested: library}
   end
 
   def insert_in_progress_library(_) do
     library = insert(:library, name: "ecto_sql")
-    insert_list(3, :chunk, library: library)
-    insert_list(1, :chunk, library: library, embedding: nil)
+    ingestion = insert(:ingestion, library: library)
+    insert_list(3, :chunk, ingestion: ingestion, library: library)
+    insert_list(1, :chunk, ingestion: ingestion, library: library, embedding: nil)
     %{in_progress: library}
   end
 

--- a/test/exmeralda/topics_test.exs
+++ b/test/exmeralda/topics_test.exs
@@ -43,4 +43,16 @@ defmodule Exmeralda.TopicsTest do
       assert in_progress.id in ids
     end
   end
+
+  describe "update_ingestion_state!/2" do
+    test "updates state of ingestion" do
+      ingestion = insert(:ingestion, state: :queued)
+
+      Topics.update_ingestion_state!(ingestion, :embedding)
+
+      ingestion = Repo.reload(ingestion)
+
+      assert ingestion.state == :embedding
+    end
+  end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -63,6 +63,13 @@ defmodule Exmeralda.Factory do
     end)
   end
 
+  def ingestion_factory do
+    %Exmeralda.Topics.Ingestion{
+      state: :queued,
+      library: build(:library)
+    }
+  end
+
   def chunk_factory do
     %Exmeralda.Topics.Chunk{
       library: build(:library),


### PR DESCRIPTION
This PR adds the ingestion schema, relates it with chunks and libraries, and creates an ingestion whenever we ingest a library within the existing ingestion process.

More state changes of the ingestion will follow when we refactor the ingestion process.

The PR also includes a data migration we must run manually to create ingestions for already existing libraries and associate each existing chunk with an ingestion.

We must enable the NOT NULL constraint on `ingestion_id` of chunks in a separate migration and deployment after we migrated the data.