### PR TITLE
[#EX-57] Enable NOT NULL constraint on ingestion_id

### DIFF
--- a/priv/repo/migrations/20250723093327_add_not_null_constraint_to_ingestion_id.exs
+++ b/priv/repo/migrations/20250723093327_add_not_null_constraint_to_ingestion_id.exs
@@ -1,0 +1,10 @@
+defmodule Exmeralda.Repo.Migrations.AddNotNullConstraintToIngestionId do
+  use Ecto.Migration
+
+  def change do
+    execute(
+      "ALTER TABLE chunks ALTER COLUMN ingestion_id SET NOT NULL;",
+      "ALTER TABLE chunks ALTER COLUMN ingestion_id DROP NOT NULL;"
+    )
+  end
+end


### PR DESCRIPTION
We must first merge #56 and run the data migration before we can merge this PR and enable the constraint.