### PR TITLE
[#EX-63] Refactor code of session new to work with ingestions

### DIFF
--- a/lib/exmeralda/chats/session.ex
+++ b/lib/exmeralda/chats/session.ex
@@ -1,7 +1,7 @@
 defmodule Exmeralda.Chats.Session do
   use Exmeralda.Schema
   alias Exmeralda.Accounts.User
-  alias Exmeralda.Topics.Library
+  alias Exmeralda.Topics.{Ingestion, Library}
   alias Exmeralda.Chats.Message
 
   @title_max_length 255
@@ -11,6 +11,7 @@ defmodule Exmeralda.Chats.Session do
     field :prompt, :string, virtual: true
     belongs_to :user, User
     belongs_to :library, Library
+    belongs_to :ingestion, Ingestion
     has_many :messages, Message, preload_order: [asc: :index]
 
     timestamps()
@@ -20,8 +21,8 @@ defmodule Exmeralda.Chats.Session do
   def create_changeset(session, attrs) do
     changeset =
       session
-      |> cast(attrs, [:library_id, :prompt])
-      |> validate_required([:library_id, :prompt])
+      |> cast(attrs, [:library_id, :ingestion_id, :prompt])
+      |> validate_required([:library_id, :ingestion_id, :prompt])
 
     title =
       changeset

--- a/lib/exmeralda/topics.ex
+++ b/lib/exmeralda/topics.ex
@@ -38,7 +38,7 @@ defmodule Exmeralda.Topics do
         desc: :version
       ]
     )
-    |> with_chunks_ready()
+    |> with_ingestion_ready()
     |> Repo.all()
   end
 
@@ -48,19 +48,6 @@ defmodule Exmeralda.Topics do
       [l],
       exists(
         from i in Ingestion, where: i.library_id == parent_as(:library).id and i.state == :ready
-      )
-    )
-  end
-
-  defp with_chunks_ready(query) do
-    where(
-      query,
-      [l],
-      not exists(
-        from c in Chunk,
-          where: c.library_id == parent_as(:library).id and is_nil(c.embedding),
-          select: 1,
-          limit: 1
       )
     )
   end

--- a/lib/exmeralda/topics.ex
+++ b/lib/exmeralda/topics.ex
@@ -127,6 +127,18 @@ defmodule Exmeralda.Topics do
   end
 
   @doc """
+  Returns the latest ingestion in state :ready for a library.
+  """
+  def current_ingestion(%Library{id: library_id}) do
+    Repo.one(
+      from i in Ingestion,
+        where: i.library_id == ^library_id and i.state == :ready,
+        order_by: [desc: :updated_at],
+        limit: 1
+    )
+  end
+
+  @doc """
   Updates the state of an ingestion.
   """
   def update_ingestion_state!(ingestion, state) do

--- a/lib/exmeralda/topics.ex
+++ b/lib/exmeralda/topics.ex
@@ -13,7 +13,7 @@ defmodule Exmeralda.Topics do
       order_by: [desc: :inserted_at],
       limit: 10
     )
-    |> with_chunks_ready()
+    |> with_ingestion_ready()
     |> Repo.all()
   end
 
@@ -40,6 +40,16 @@ defmodule Exmeralda.Topics do
     )
     |> with_chunks_ready()
     |> Repo.all()
+  end
+
+  defp with_ingestion_ready(query) do
+    where(
+      query,
+      [l],
+      exists(
+        from i in Ingestion, where: i.library_id == parent_as(:library).id and i.state == :ready
+      )
+    )
   end
 
   defp with_chunks_ready(query) do

--- a/lib/exmeralda_web/live/chat_live/start_chat.ex
+++ b/lib/exmeralda_web/live/chat_live/start_chat.ex
@@ -94,7 +94,11 @@ defmodule ExmeraldaWeb.ChatLive.StartChat do
 
   @impl true
   def handle_event("start", %{"session" => session_params}, socket) do
-    case Chats.start_session(socket.assigns.user, session_params) do
+    current_ingestion = Topics.current_ingestion(socket.assigns.selected_library)
+
+    params = Map.put(session_params, "ingestion_id", current_ingestion.id)
+
+    case Chats.start_session(socket.assigns.user, params) do
       {:ok, session} ->
         notify_parent({:start, Map.put(session, :library, socket.assigns.selected_library)})
 

--- a/priv/repo/migrations/20250723132813_add_ingestion_id_to_chat_sessions.exs
+++ b/priv/repo/migrations/20250723132813_add_ingestion_id_to_chat_sessions.exs
@@ -1,0 +1,38 @@
+defmodule Exmeralda.Repo.Migrations.AddIngestionIdToChatSessions do
+  use Ecto.Migration
+
+  def up do
+    alter table("chat_sessions") do
+      add :ingestion_id, references(:ingestions, on_delete: :delete_all), null: true
+    end
+
+    flush()
+
+    execute("""
+      UPDATE
+        chat_sessions
+      SET
+        ingestion_id = ingestions.id
+      FROM
+        ingestions
+      WHERE
+        chat_sessions.ingestion_id IS NULL
+        AND chat_sessions.library_id = ingestions.library_id;
+    """)
+
+    flush()
+
+    execute("""
+      ALTER TABLE
+        chat_sessions ALTER COLUMN ingestion_id
+      SET
+        NOT NULL;
+    """)
+  end
+
+  def down do
+    alter table("chat_sessions") do
+      remove :ingestion_id
+    end
+  end
+end

--- a/test/exmeralda/topics_test.exs
+++ b/test/exmeralda/topics_test.exs
@@ -2,7 +2,7 @@ defmodule Exmeralda.TopicsTest do
   use Exmeralda.DataCase
 
   alias Exmeralda.Topics
-  alias Exmeralda.Topics.Chunk
+  alias Exmeralda.Topics.Ingestion
 
   def insert_ingested_library(_) do
     library = insert(:library, name: "ecto")
@@ -16,7 +16,7 @@ defmodule Exmeralda.TopicsTest do
     ingestion = insert(:ingestion, library: library, state: :embedding)
     insert_list(3, :chunk, ingestion: ingestion, library: library)
     insert_list(1, :chunk, ingestion: ingestion, library: library, embedding: nil)
-    %{in_progress: library}
+    %{in_progress: library, in_progress_ingestion: ingestion}
   end
 
   def insert_chunkless_library(_) do
@@ -46,14 +46,15 @@ defmodule Exmeralda.TopicsTest do
     test "returns only libraries that are ingested fully and match the term", %{
       ingested: ingested,
       chunkless: chunkless,
-      in_progress: in_progress
+      in_progress: in_progress,
+      in_progress_ingestion: in_progress_ingestion
     } do
       ids = Topics.search_libraries("ecto") |> Enum.map(& &1.id)
       assert ingested.id in ids
-      assert chunkless.id in ids
+      refute chunkless.id in ids
       refute in_progress.id in ids
 
-      from(c in Chunk, where: is_nil(c.embedding)) |> Exmeralda.Repo.delete_all()
+      Ingestion.set_state(in_progress_ingestion, :ready) |> Repo.update!()
 
       ids = Topics.search_libraries("ecto") |> Enum.map(& &1.id)
       assert in_progress.id in ids

--- a/test/exmeralda/topics_test.exs
+++ b/test/exmeralda/topics_test.exs
@@ -72,4 +72,31 @@ defmodule Exmeralda.TopicsTest do
       assert ingestion.state == :embedding
     end
   end
+
+  describe "current_ingestion/1" do
+    test "returns nil when no ingestion" do
+      library = insert(:library)
+
+      refute Topics.current_ingestion(library)
+    end
+
+    test "returns the latest ingestion in state :ready for a library" do
+      library = insert(:library)
+      queued_ingestion = insert(:ingestion, library: library)
+
+      refute Topics.current_ingestion(library)
+
+      ready_ingestion = Ingestion.set_state(queued_ingestion, :ready) |> Repo.update!()
+
+      assert Topics.current_ingestion(library).id == ready_ingestion.id
+
+      _non_ready_ingestion = insert(:ingestion, library: library)
+
+      assert Topics.current_ingestion(library).id == ready_ingestion.id
+
+      new_ready_ingestion = insert(:ingestion, library: library, state: :ready)
+
+      assert Topics.current_ingestion(library).id == new_ready_ingestion.id
+    end
+  end
 end

--- a/test/exmeralda_web/live/chat_live_test.exs
+++ b/test/exmeralda_web/live/chat_live_test.exs
@@ -5,7 +5,10 @@ defmodule ExmeraldaWeb.ChatLiveTest do
   alias Exmeralda.{Repo, Chats.Session}
 
   defp insert_library(_) do
-    %{library: insert(:library, name: "ecto")}
+    library = insert(:library, name: "ecto")
+    ingestion = insert(:ingestion, library: library, state: :ready)
+
+    %{library: library, ingestion: ingestion}
   end
 
   defp insert_session(%{user: user, library: library}) do


### PR DESCRIPTION
This PR associates chat sessions with ingestions and refactors the code so that

1. each chat session is started with an associated ingestions
2. you can only start chat sessions about libraries that have at least one ingestion in state `ready`

As part of the migration, existing chat sessions are associated with an ingestion for their associated library.