### PR TITLE
[EX-91] library_id is redundant on chunks

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,13 @@ Now you can visit [`localhost:4000`](http://localhost:4000) from your browser.
 - http://localhost:4000/dev/mailbox for the Swoosh dev mailbox
 - http://localhost:4000/oban for the Oban dashboard
 - http://localhost:4000/admin for our admin interface
+
+## Deployment
+
+The deployment is done with [Fly.io](https://fly.io/docs/elixir/).
+
+Follow [this guide](https://fly.io/docs/elixir/the-basics/iex-into-running-app/) to run an IEx console on production:
+
+```sh
+fly ssh console --pty -C "/app/bin/exmeralda remote"
+```

--- a/lib/exmeralda/chats.ex
+++ b/lib/exmeralda/chats.ex
@@ -148,7 +148,7 @@ defmodule Exmeralda.Chats do
     }
 
     Task.Supervisor.start_child(Exmeralda.TaskSupervisor, fn ->
-      {chunks, generation} = build_generation(message, session.ingestion.library_id)
+      {chunks, generation} = build_generation(message, session.ingestion.id)
       insert_sources(session, chunks, assistant_message)
 
       LLM.stream_responses(
@@ -158,8 +158,8 @@ defmodule Exmeralda.Chats do
     end)
   end
 
-  defp build_generation(message, library_id) do
-    scope = from c in Chunk, where: c.library_id == ^library_id
+  defp build_generation(message, ingestion_id) do
+    scope = from c in Chunk, where: c.ingestion_id == ^ingestion_id
 
     Rag.build_generation(scope, message.content, ref: message)
   end

--- a/lib/exmeralda/topics/chunk.ex
+++ b/lib/exmeralda/topics/chunk.ex
@@ -1,7 +1,5 @@
 defmodule Exmeralda.Topics.Chunk do
   use Exmeralda.Schema
-
-  alias Exmeralda.Topics.Library
   alias Exmeralda.Topics.Ingestion
 
   @derive {Flop.Schema,
@@ -15,8 +13,8 @@ defmodule Exmeralda.Topics.Chunk do
     field :source, :string
     field :content, :string
     field(:embedding, Pgvector.Ecto.Vector)
-    belongs_to(:library, Library)
     belongs_to(:ingestion, Ingestion)
+    has_one :library, through: [:ingestion, :library]
   end
 
   def set_embedding(chunk, embedding) do

--- a/lib/exmeralda/topics/generate_embeddings_worker.ex
+++ b/lib/exmeralda/topics/generate_embeddings_worker.ex
@@ -17,7 +17,7 @@ defmodule Exmeralda.Topics.GenerateEmbeddingsWorker do
     Repo.transact(fn ->
       with {:ok, ingestion} <- fetch_ingestion(ingestion_id, library_id: library_id) do
         {:ok,
-         from(c in Chunk, where: c.library_id == ^library_id, select: c.id)
+         from(c in Chunk, where: c.ingestion_id == ^ingestion_id, select: c.id)
          |> Repo.all()
          |> Enum.chunk_every(@embeddings_batch_size)
          |> Enum.map(

--- a/lib/exmeralda/topics/ingest_library_worker.ex
+++ b/lib/exmeralda/topics/ingest_library_worker.ex
@@ -74,12 +74,7 @@ defmodule Exmeralda.Topics.IngestLibraryWorker do
     chunks
     |> Enum.chunk_every(@insert_batch_size)
     |> Enum.each(fn batch ->
-      batch =
-        Enum.map(
-          batch,
-          &Map.merge(&1, %{ingestion_id: ingestion.id, library_id: ingestion.library_id})
-        )
-
+      batch = Enum.map(batch, &Map.merge(&1, %{ingestion_id: ingestion.id}))
       Repo.insert_all(Chunk, batch)
     end)
 

--- a/lib/exmeralda/topics/library.ex
+++ b/lib/exmeralda/topics/library.ex
@@ -1,7 +1,7 @@
 defmodule Exmeralda.Topics.Library do
   use Exmeralda.Schema
 
-  alias Exmeralda.Topics.{Dependency, Chunk, Ingestion}
+  alias Exmeralda.Topics.{Dependency, Ingestion}
 
   @derive {
     Flop.Schema,
@@ -20,7 +20,6 @@ defmodule Exmeralda.Topics.Library do
     field :version, :string
     embeds_many :dependencies, Dependency, on_replace: :delete
 
-    has_many :chunks, Chunk
     has_many :ingestions, Ingestion
 
     timestamps()

--- a/priv/repo/migrations/20250819143114_remove_library_id_from_chunks.exs
+++ b/priv/repo/migrations/20250819143114_remove_library_id_from_chunks.exs
@@ -1,0 +1,32 @@
+defmodule Exmeralda.Repo.Migrations.RemoveLibraryIdFromChunks do
+  use Ecto.Migration
+
+  def up do
+    alter table("chunks") do
+      remove :library_id
+    end
+  end
+
+  def down do
+    alter table("chunks") do
+      add :library_id, references(:libraries, on_delete: :delete_all), null: true
+    end
+
+    execute("""
+    UPDATE
+      chunks
+    SET
+      library_id = ingestions.library_id
+    FROM
+      ingestions
+    WHERE
+      chunks.ingestion_id = ingestions.id;
+    """)
+
+    alter table("chunks") do
+      modify :library_id, references(:libraries, on_delete: :delete_all),
+        null: false,
+        from: references(:libraries, on_delete: :delete_all)
+    end
+  end
+end


### PR DESCRIPTION
We don't need to keep the library_id column on chunks, it's redundant with ingestion_id. 