### PR TITLE
[EX-43] +1 and -1 for answers

### DIFF
--- a/lib/exmeralda/chats.ex
+++ b/lib/exmeralda/chats.ex
@@ -239,12 +239,15 @@ defmodule Exmeralda.Chats do
   @doc """
   Deletes a reaction.
   """
-  @spec delete_reaction(Reaction.id()) :: {:ok, Reaction.t()} | {:error, {:not_found, Reaction}}
+  @spec delete_reaction(Reaction.id()) :: :ok
   def delete_reaction(reaction_id) do
-    Repo.transact(fn ->
-      with {:ok, reaction} <- Repo.fetch(Reaction, reaction_id) do
-        {:ok, Repo.delete!(reaction)}
-      end
-    end)
+    case Repo.fetch(Reaction, reaction_id) do
+      {:ok, reaction} ->
+        Repo.delete(reaction, allow_stale: true)
+        :ok
+
+      _ ->
+        :ok
+    end
   end
 end

--- a/lib/exmeralda/chats.ex
+++ b/lib/exmeralda/chats.ex
@@ -184,11 +184,14 @@ defmodule Exmeralda.Chats do
   @doc """
   Deletes a session.
   """
-  @spec unlink_user_from_session!(Session.t()) :: Session.t()
-  def unlink_user_from_session!(%Session{} = session) do
-    session
-    |> Session.unset_user_changeset()
-    |> Repo.update!()
+  @spec unlink_user_from_session(User.id(), Session.id()) ::
+          {:ok, Session.t()} | {:error, {:not_found, Session}}
+  def unlink_user_from_session(user_id, session_id) do
+    with {:ok, session} <- Repo.fetch_by(Session, id: session_id, user_id: user_id) do
+      session
+      |> Session.unset_user_changeset()
+      |> Repo.update()
+    end
   end
 
   @doc """

--- a/lib/exmeralda/chats.ex
+++ b/lib/exmeralda/chats.ex
@@ -206,7 +206,7 @@ defmodule Exmeralda.Chats do
   end
 
   @doc """
-  Upserts a reaction for a message in a session.
+  Upserts a reaction for a message.
   """
   @spec upsert_reaction(Message.id(), atom()) ::
           {:ok, Message.t()}

--- a/lib/exmeralda/chats/message.ex
+++ b/lib/exmeralda/chats/message.ex
@@ -1,7 +1,7 @@
 defmodule Exmeralda.Chats.Message do
   use Exmeralda.Schema
 
-  alias Exmeralda.Chats.{Session, Source}
+  alias Exmeralda.Chats.{Reaction, Session, Source}
 
   schema "chat_messages" do
     field :index, :integer
@@ -14,6 +14,8 @@ defmodule Exmeralda.Chats.Message do
     has_many :source_chunks,
       through: [:sources, :chunk],
       preload_order: [asc: :type, asc: :source]
+
+    has_one :reaction, Reaction
 
     timestamps()
   end

--- a/lib/exmeralda/chats/reaction.ex
+++ b/lib/exmeralda/chats/reaction.ex
@@ -17,13 +17,4 @@ defmodule Exmeralda.Chats.Reaction do
 
     timestamps()
   end
-
-  @fields [:message_id, :user_id, :ingestion_id, :type]
-
-  @doc false
-  def changeset(message \\ %__MODULE__{}, attrs) do
-    message
-    |> cast(attrs, @fields)
-    |> validate_required(@fields)
-  end
 end

--- a/lib/exmeralda/chats/reaction.ex
+++ b/lib/exmeralda/chats/reaction.ex
@@ -3,8 +3,13 @@ defmodule Exmeralda.Chats.Reaction do
 
   alias Exmeralda.Accounts.User
   alias Exmeralda.Chats.Message
+  alias Exmeralda.Topics.Ingestion
 
   schema "chat_reactions" do
+    # Since chat session and messages can be deleted by the user, we preserve the link
+    # to the ingestion on the reaction so that statistics can be made for a given ingestion
+    # even if all messages were deleted.
+    belongs_to :ingestion, Ingestion
     belongs_to :message, Message
     belongs_to :user, User
 
@@ -13,13 +18,12 @@ defmodule Exmeralda.Chats.Reaction do
     timestamps()
   end
 
-  @fields [:message_id, :user_id, :type]
+  @fields [:message_id, :user_id, :ingestion_id, :type]
 
   @doc false
   def changeset(message \\ %__MODULE__{}, attrs) do
     message
     |> cast(attrs, @fields)
     |> validate_required(@fields)
-    |> unique_constraint([:message_id, :user_id])
   end
 end

--- a/lib/exmeralda/chats/reaction.ex
+++ b/lib/exmeralda/chats/reaction.ex
@@ -3,13 +3,8 @@ defmodule Exmeralda.Chats.Reaction do
 
   alias Exmeralda.Accounts.User
   alias Exmeralda.Chats.Message
-  alias Exmeralda.Topics.Ingestion
 
   schema "chat_reactions" do
-    # Since chat session and messages can be deleted by the user, we preserve the link
-    # to the ingestion on the reaction so that statistics can be made for a given ingestion
-    # even if all messages were deleted.
-    belongs_to :ingestion, Ingestion
     belongs_to :message, Message
     belongs_to :user, User
 

--- a/lib/exmeralda/chats/reaction.ex
+++ b/lib/exmeralda/chats/reaction.ex
@@ -1,0 +1,25 @@
+defmodule Exmeralda.Chats.Reaction do
+  use Exmeralda.Schema
+
+  alias Exmeralda.Accounts.User
+  alias Exmeralda.Chats.Message
+
+  schema "chat_reactions" do
+    belongs_to :message, Message
+    belongs_to :user, User
+
+    field :type, Ecto.Enum, values: [:upvote, :downvote]
+
+    timestamps()
+  end
+
+  @fields [:message_id, :user_id, :type]
+
+  @doc false
+  def changeset(message \\ %__MODULE__{}, attrs) do
+    message
+    |> cast(attrs, @fields)
+    |> validate_required(@fields)
+    |> unique_constraint([:message_id, :user_id])
+  end
+end

--- a/lib/exmeralda/chats/reaction.ex
+++ b/lib/exmeralda/chats/reaction.ex
@@ -1,12 +1,10 @@
 defmodule Exmeralda.Chats.Reaction do
   use Exmeralda.Schema
 
-  alias Exmeralda.Accounts.User
   alias Exmeralda.Chats.Message
 
   schema "chat_reactions" do
     belongs_to :message, Message
-    belongs_to :user, User
 
     field :type, Ecto.Enum, values: [:upvote, :downvote]
 

--- a/lib/exmeralda/chats/session.ex
+++ b/lib/exmeralda/chats/session.ex
@@ -36,4 +36,9 @@ defmodule Exmeralda.Chats.Session do
   def set_title_changeset(session, title) do
     change(session, title: title)
   end
+
+  @doc false
+  def unset_user_changeset(session) do
+    change(session, user_id: nil)
+  end
 end

--- a/lib/exmeralda/schema.ex
+++ b/lib/exmeralda/schema.ex
@@ -1,7 +1,7 @@
 defmodule Exmeralda.Schema do
   defmacro __using__(_) do
     quote do
-      use Ecto.Schema
+      use BitcrowdEcto.Schema
       import Ecto.Changeset
       import BitcrowdEcto.Changeset
 

--- a/lib/exmeralda/topics.ex
+++ b/lib/exmeralda/topics.ex
@@ -160,7 +160,7 @@ defmodule Exmeralda.Topics do
   end
 
   @doc """
-  Deletes a libray.
+  Deletes a library.
   """
   def delete_library(library) do
     Repo.delete(library, allow_stale: true)

--- a/lib/exmeralda_web/live/chat_live/chat.ex
+++ b/lib/exmeralda_web/live/chat_live/chat.ex
@@ -56,6 +56,32 @@ defmodule ExmeraldaWeb.ChatLive.Chat do
   end
 
   @impl true
+  def handle_event("upvote", %{"value" => message_id}, socket) do
+    user_id = socket.assigns.session.user_id
+
+    case Chats.toggle_reaction(message_id, user_id, :upvote) do
+      {:ok, _reaction} ->
+        message = Chats.get_message!(message_id)
+        {:noreply, stream_insert(socket, :messages, message, update_only: true)}
+
+      {:error, _error} ->
+        {:noreply, socket}
+    end
+  end
+
+  def handle_event("downvote", %{"value" => message_id}, socket) do
+    user_id = socket.assigns.session.user_id
+
+    case Chats.toggle_reaction(message_id, user_id, :downvote) do
+      {:ok, _reaction} ->
+        message = Chats.get_message!(message_id)
+        {:noreply, stream_insert(socket, :messages, message, update_only: true)}
+
+      {:error, _error} ->
+        {:noreply, socket}
+    end
+  end
+
   def handle_event("send", %{"message" => message_params}, socket) do
     socket.assigns.session
     |> Chats.continue_session(message_params)
@@ -136,8 +162,34 @@ defmodule ExmeraldaWeb.ChatLive.Chat do
               </ul>
             </details>
           </div>
-          <div class="chat-footer opacity-50">
-            <span :if={message.incomplete} class="loading loading-dots loading-xs"></span>
+          <div class="chat-footer p-2 gap-4">
+            <div :if={message.role == :assistant}>
+              <.button
+                id="upvote"
+                class={[
+                  "btn btn-xs btn-soft btn-circle btn-success btn-outline",
+                  message.reaction && message.reaction.type == :upvote && "btn-active"
+                ]}
+                phx-click="upvote"
+                value={message.id}
+                phx-target={@myself}
+              >
+                <.icon name="hero-hand-thumb-up" />
+              </.button>
+              <.button
+                id="downvote"
+                class={[
+                  "btn btn-xs btn-soft btn-circle btn-error",
+                  message.reaction && message.reaction.type == :downvote && "btn-active"
+                ]}
+                phx-click="downvote"
+                value={message.id}
+                phx-target={@myself}
+              >
+                <.icon name="hero-hand-thumb-down" />
+              </.button>
+            </div>
+            <span :if={message.incomplete} class="opacity-50 loading loading-dots loading-xs"></span>
           </div>
         </div>
       </div>

--- a/lib/exmeralda_web/live/chat_live/chat.ex
+++ b/lib/exmeralda_web/live/chat_live/chat.ex
@@ -100,7 +100,7 @@ defmodule ExmeraldaWeb.ChatLive.Chat do
   defp handle_add_vote(socket, message_id, type) do
     %{session: session} = socket.assigns
 
-    case Chats.upsert_reaction(message_id, session.id, type) do
+    case Chats.upsert_reaction(message_id, type) do
       {:ok, message} ->
         {:noreply, stream_insert(socket, :messages, message, update_only: true)}
 
@@ -110,7 +110,7 @@ defmodule ExmeraldaWeb.ChatLive.Chat do
       {:error, {:not_found, _}} ->
         {:noreply,
          socket
-         |> put_flash(:error, gettext("The session was deleted and the vote cannot be recorded."))
+         |> put_flash(:error, gettext("Something went wrong"))
          |> push_navigate(to: ~p"/chat/start")}
     end
   end

--- a/lib/exmeralda_web/live/chat_live/chat.ex
+++ b/lib/exmeralda_web/live/chat_live/chat.ex
@@ -172,12 +172,12 @@ defmodule ExmeraldaWeb.ChatLive.Chat do
               </ul>
             </details>
           </div>
-          <div class="chat-footer p-2 gap-4">
-            <div :if={message.role == :assistant}>
-              <.vote_button message={message} type={:upvote} target={@myself} />
-              <.vote_button message={message} type={:downvote} target={@myself} />
-            </div>
-            <span :if={message.incomplete} class="opacity-50 loading loading-dots loading-xs"></span>
+          <div :if={message.incomplete} class="chat-footer opacity-50">
+            <span class="loading loading-dots loading-xs"></span>
+          </div>
+          <div :if={!message.incomplete && message.role == :assistant} class="chat-footer p-2">
+            <.vote_button message={message} type={:upvote} target={@myself} />
+            <.vote_button message={message} type={:downvote} target={@myself} />
           </div>
         </div>
       </div>

--- a/lib/exmeralda_web/live/chat_live/index.ex
+++ b/lib/exmeralda_web/live/chat_live/index.ex
@@ -22,7 +22,7 @@ defmodule ExmeraldaWeb.ChatLive.Index do
   end
 
   defp apply_action(socket, :show, %{"id" => id}) do
-    session = Chats.get_session!(socket.assigns.current_user, id)
+    session = Chats.get_session!(socket.assigns.current_user.id, id)
 
     socket
     |> assign(:page_title, session.title)
@@ -79,8 +79,13 @@ defmodule ExmeraldaWeb.ChatLive.Index do
 
   @impl true
   def handle_event("delete", %{"id" => id}, socket) do
-    session = Chats.get_session!(socket.assigns.current_user, id)
-    {:ok, _} = Chats.delete_session(session)
+    session =
+      socket.assigns.current_user.id
+      |> Chats.get_session!(id)
+      # We want to preserve sessions and messages to be able to produce meaningful
+      # statistics on the quality of the answers. Instead of deleting the session,
+      # we just nilify the user_id.
+      |> Chats.unlink_user_from_session!()
 
     socket = stream_delete(socket, :sessions, session)
 

--- a/lib/exmeralda_web/live/chat_live/index.html.heex
+++ b/lib/exmeralda_web/live/chat_live/index.html.heex
@@ -45,7 +45,7 @@
         <.button
           phx-click={JS.push("delete", value: %{id: session.id}) |> hide("##{id}")}
           data-confirm="Are you sure?"
-          class="btn-square absolute right-2 top-2 hover:text-error"
+          class={"btn-square absolute right-2 top-2 hover:text-error e2e-delete-session-#{session.id}"}
         >
           <span class="sr-only">{gettext("Delete")}</span>
           <.icon name="hero-x-mark" class="shrink-0" />

--- a/priv/repo/migrations/20250811082640_create_reactions.exs
+++ b/priv/repo/migrations/20250811082640_create_reactions.exs
@@ -1,0 +1,17 @@
+defmodule Exmeralda.Repo.Migrations.CreateReactions do
+  use Ecto.Migration
+
+  def change do
+    execute("CREATE TYPE reaction_type AS ENUM ('upvote','downvote')", "DROP TYPE reaction_type")
+
+    create table(:chat_reactions) do
+      add :message_id, references(:chat_messages, on_delete: :delete_all), null: false
+      add :user_id, references(:users, on_delete: :delete_all), null: false
+      add :type, :reaction_type
+
+      timestamps()
+    end
+
+    create unique_index(:chat_reactions, [:message_id, :user_id])
+  end
+end

--- a/priv/repo/migrations/20250819143114_remove_library_id_from_chunks.exs
+++ b/priv/repo/migrations/20250819143114_remove_library_id_from_chunks.exs
@@ -28,5 +28,7 @@ defmodule Exmeralda.Repo.Migrations.RemoveLibraryIdFromChunks do
         null: false,
         from: references(:libraries, on_delete: :delete_all)
     end
+
+    create index("chunks", [:library_id])
   end
 end

--- a/priv/repo/migrations/20250819162640_create_reactions.exs
+++ b/priv/repo/migrations/20250819162640_create_reactions.exs
@@ -5,13 +5,15 @@ defmodule Exmeralda.Repo.Migrations.CreateReactions do
     execute("CREATE TYPE reaction_type AS ENUM ('upvote','downvote')", "DROP TYPE reaction_type")
 
     create table(:chat_reactions) do
-      add :message_id, references(:chat_messages, on_delete: :delete_all), null: false
-      add :user_id, references(:users, on_delete: :delete_all), null: false
+      add :ingestion_id, references(:ingestions, on_delete: :delete_all), null: false
+      add :message_id, references(:chat_messages, on_delete: :nilify_all), null: true
+      add :user_id, references(:users, on_delete: :nilify_all), null: true
       add :type, :reaction_type
 
       timestamps()
     end
 
     create unique_index(:chat_reactions, [:message_id, :user_id])
+    create index(:chat_reactions, [:ingestion_id])
   end
 end

--- a/priv/repo/migrations/20250819162640_create_reactions.exs
+++ b/priv/repo/migrations/20250819162640_create_reactions.exs
@@ -6,19 +6,25 @@ defmodule Exmeralda.Repo.Migrations.CreateReactions do
       modify :user_id, references(:users, on_delete: :nilify_all),
         from: references(:users, on_delete: :delete_all),
         null: true
+
+      modify :ingestion_id, references(:ingestions, on_delete: :restrict),
+        from: references(:ingestions, on_delete: :delete_all)
+    end
+
+    alter table(:chat_messages) do
+      modify :session_id, references(:chat_sessions, on_delete: :restrict),
+        from: references(:chat_sessions, on_delete: :delete_all)
     end
 
     execute("CREATE TYPE reaction_type AS ENUM ('upvote','downvote')", "DROP TYPE reaction_type")
 
     create table(:chat_reactions) do
-      add :message_id, references(:chat_messages, on_delete: :delete_all), null: false
-      add :user_id, references(:users, on_delete: :nilify_all), null: true
+      add :message_id, references(:chat_messages, on_delete: :restrict), null: false
       add :type, :reaction_type
 
       timestamps()
     end
 
-    create unique_index(:chat_reactions, [:message_id, :user_id])
-    create index(:chat_reactions, [:message_id])
+    create unique_index(:chat_reactions, [:message_id])
   end
 end

--- a/priv/repo/migrations/20250819162640_create_reactions.exs
+++ b/priv/repo/migrations/20250819162640_create_reactions.exs
@@ -2,11 +2,16 @@ defmodule Exmeralda.Repo.Migrations.CreateReactions do
   use Ecto.Migration
 
   def change do
+    alter table(:chat_sessions) do
+      modify :user_id, references(:users, on_delete: :nilify_all),
+        from: references(:users, on_delete: :delete_all),
+        null: true
+    end
+
     execute("CREATE TYPE reaction_type AS ENUM ('upvote','downvote')", "DROP TYPE reaction_type")
 
     create table(:chat_reactions) do
-      add :ingestion_id, references(:ingestions, on_delete: :delete_all), null: false
-      add :message_id, references(:chat_messages, on_delete: :nilify_all), null: true
+      add :message_id, references(:chat_messages, on_delete: :delete_all), null: false
       add :user_id, references(:users, on_delete: :nilify_all), null: true
       add :type, :reaction_type
 
@@ -14,6 +19,6 @@ defmodule Exmeralda.Repo.Migrations.CreateReactions do
     end
 
     create unique_index(:chat_reactions, [:message_id, :user_id])
-    create index(:chat_reactions, [:ingestion_id])
+    create index(:chat_reactions, [:message_id])
   end
 end

--- a/test/exmeralda/chats/reaction_test.exs
+++ b/test/exmeralda/chats/reaction_test.exs
@@ -1,30 +1,84 @@
 defmodule Exmeralda.Chats.ReactionTest do
   use Exmeralda.DataCase
-
-  import BitcrowdEcto.Random
-
   alias Exmeralda.Chats.Reaction
+  alias Exmeralda.Repo
+
+  describe "table" do
+    test "unique reaction by message and user" do
+      user = insert(:user)
+      message = insert(:message)
+      ingestion = insert(:ingestion)
+
+      insert(:reaction, ingestion: ingestion, message: message, user: user, type: :upvote)
+
+      assert_raise Ecto.ConstraintError, ~r/chat_reactions_message_id_user_id_index/, fn ->
+        insert(:reaction, ingestion: ingestion, message: message, user: user, type: :upvote)
+      end
+    end
+  end
+
+  describe "nilify behaviour" do
+    setup do
+      user = insert(:user)
+      ingestion = insert(:ingestion)
+      chat_session = insert(:chat_session, user: user, ingestion: ingestion)
+      message = insert(:message, session: chat_session)
+
+      reaction =
+        insert(:reaction, ingestion: ingestion, message: message, user: user, type: :upvote)
+
+      %{user: user, chat_session: chat_session, message: message, reaction: reaction}
+    end
+
+    test "message is nilified on deletion of the chat session", %{
+      chat_session: chat_session,
+      message: message,
+      reaction: reaction
+    } do
+      Repo.delete(chat_session)
+
+      refute Repo.reload(chat_session)
+      refute Repo.reload(message)
+
+      reaction = Repo.reload(reaction)
+      refute reaction.message_id
+      assert reaction.user_id
+      assert reaction.ingestion_id
+    end
+
+    test "user is nilified on deletion of the user", %{
+      user: user,
+      chat_session: chat_session,
+      message: message,
+      reaction: reaction
+    } do
+      Repo.delete(user)
+
+      refute Repo.reload(chat_session)
+      refute Repo.reload(message)
+
+      reaction = Repo.reload(reaction)
+      refute reaction.message_id
+      refute reaction.user_id
+      assert reaction.ingestion_id
+    end
+  end
 
   describe "changeset/2" do
     test "is valid with valid params" do
-      params = %{"user_id" => uuid(), "message_id" => uuid(), "type" => "upvote"}
-
-      changeset = Reaction.changeset(params)
-
-      assert changeset.valid?
+      %{user_id: uuid(), message_id: uuid(), ingestion_id: uuid(), type: :upvote}
+      |> Reaction.changeset()
+      |> assert_changeset_valid()
     end
 
-    test "validates unique reaction by message and user" do
-      user = insert(:user)
-      session = insert(:chat_session, user: user)
-      message = insert(:message, session: session)
-      reation = insert(:reaction, message: message, user: user, type: :upvote)
-
-      params = %{"user_id" => user.id, "message_id" => message.id, "type" => "downvote"}
-
-      changeset = Reaction.changeset(params)
-
-      refute changeset.valid?
+    test "is invalid with invalid params" do
+      %{}
+      |> Reaction.changeset()
+      |> refute_changeset_valid()
+      |> assert_required_error_on(:ingestion_id)
+      |> assert_required_error_on(:message_id)
+      |> assert_required_error_on(:type)
+      |> assert_required_error_on(:user_id)
     end
   end
 end

--- a/test/exmeralda/chats/reaction_test.exs
+++ b/test/exmeralda/chats/reaction_test.exs
@@ -1,0 +1,30 @@
+defmodule Exmeralda.Chats.ReactionTest do
+  use Exmeralda.DataCase
+
+  import BitcrowdEcto.Random
+
+  alias Exmeralda.Chats.Reaction
+
+  describe "changeset/2" do
+    test "is valid with valid params" do
+      params = %{"user_id" => uuid(), "message_id" => uuid(), "type" => "upvote"}
+
+      changeset = Reaction.changeset(params)
+
+      assert changeset.valid?
+    end
+
+    test "validates unique reaction by message and user" do
+      user = insert(:user)
+      session = insert(:chat_session, user: user)
+      message = insert(:message, session: session)
+      reation = insert(:reaction, message: message, user: user, type: :upvote)
+
+      params = %{"user_id" => user.id, "message_id" => message.id, "type" => "downvote"}
+
+      changeset = Reaction.changeset(params)
+
+      refute changeset.valid?
+    end
+  end
+end

--- a/test/exmeralda/chats/reaction_test.exs
+++ b/test/exmeralda/chats/reaction_test.exs
@@ -6,12 +6,11 @@ defmodule Exmeralda.Chats.ReactionTest do
     test "unique reaction by message and user" do
       user = insert(:user)
       message = insert(:message)
-      ingestion = insert(:ingestion)
 
-      insert(:reaction, ingestion: ingestion, message: message, user: user, type: :upvote)
+      insert(:reaction, message: message, user: user, type: :upvote)
 
       assert_raise Ecto.ConstraintError, ~r/chat_reactions_message_id_user_id_index/, fn ->
-        insert(:reaction, ingestion: ingestion, message: message, user: user, type: :upvote)
+        insert(:reaction, message: message, user: user, type: :upvote)
       end
     end
   end
@@ -23,26 +22,9 @@ defmodule Exmeralda.Chats.ReactionTest do
       chat_session = insert(:chat_session, user: user, ingestion: ingestion)
       message = insert(:message, session: chat_session)
 
-      reaction =
-        insert(:reaction, ingestion: ingestion, message: message, user: user, type: :upvote)
+      reaction = insert(:reaction, message: message, user: user, type: :upvote)
 
       %{user: user, chat_session: chat_session, message: message, reaction: reaction}
-    end
-
-    test "message is nilified on deletion of the chat session", %{
-      chat_session: chat_session,
-      message: message,
-      reaction: reaction
-    } do
-      Repo.delete(chat_session)
-
-      refute Repo.reload(chat_session)
-      refute Repo.reload(message)
-
-      reaction = Repo.reload(reaction)
-      refute reaction.message_id
-      assert reaction.user_id
-      assert reaction.ingestion_id
     end
 
     test "user is nilified on deletion of the user", %{
@@ -53,13 +35,12 @@ defmodule Exmeralda.Chats.ReactionTest do
     } do
       Repo.delete(user)
 
-      refute Repo.reload(chat_session)
-      refute Repo.reload(message)
+      assert Repo.reload(chat_session)
+      assert Repo.reload(message)
 
       reaction = Repo.reload(reaction)
-      refute reaction.message_id
+      assert reaction.message_id
       refute reaction.user_id
-      assert reaction.ingestion_id
     end
   end
 end

--- a/test/exmeralda/chats/reaction_test.exs
+++ b/test/exmeralda/chats/reaction_test.exs
@@ -1,6 +1,5 @@
 defmodule Exmeralda.Chats.ReactionTest do
   use Exmeralda.DataCase
-  alias Exmeralda.Chats.Reaction
   alias Exmeralda.Repo
 
   describe "table" do
@@ -61,24 +60,6 @@ defmodule Exmeralda.Chats.ReactionTest do
       refute reaction.message_id
       refute reaction.user_id
       assert reaction.ingestion_id
-    end
-  end
-
-  describe "changeset/2" do
-    test "is valid with valid params" do
-      %{user_id: uuid(), message_id: uuid(), ingestion_id: uuid(), type: :upvote}
-      |> Reaction.changeset()
-      |> assert_changeset_valid()
-    end
-
-    test "is invalid with invalid params" do
-      %{}
-      |> Reaction.changeset()
-      |> refute_changeset_valid()
-      |> assert_required_error_on(:ingestion_id)
-      |> assert_required_error_on(:message_id)
-      |> assert_required_error_on(:type)
-      |> assert_required_error_on(:user_id)
     end
   end
 end

--- a/test/exmeralda/chats/reaction_test.exs
+++ b/test/exmeralda/chats/reaction_test.exs
@@ -1,46 +1,15 @@
 defmodule Exmeralda.Chats.ReactionTest do
   use Exmeralda.DataCase
-  alias Exmeralda.Repo
 
   describe "table" do
-    test "unique reaction by message and user" do
-      user = insert(:user)
+    test "unique reaction by message" do
       message = insert(:message)
 
-      insert(:reaction, message: message, user: user, type: :upvote)
+      insert(:reaction, message: message, type: :upvote)
 
-      assert_raise Ecto.ConstraintError, ~r/chat_reactions_message_id_user_id_index/, fn ->
-        insert(:reaction, message: message, user: user, type: :upvote)
+      assert_raise Ecto.ConstraintError, ~r/chat_reactions_message_id_index/, fn ->
+        insert(:reaction, message: message, type: :upvote)
       end
-    end
-  end
-
-  describe "nilify behaviour" do
-    setup do
-      user = insert(:user)
-      ingestion = insert(:ingestion)
-      chat_session = insert(:chat_session, user: user, ingestion: ingestion)
-      message = insert(:message, session: chat_session)
-
-      reaction = insert(:reaction, message: message, user: user, type: :upvote)
-
-      %{user: user, chat_session: chat_session, message: message, reaction: reaction}
-    end
-
-    test "user is nilified on deletion of the user", %{
-      user: user,
-      chat_session: chat_session,
-      message: message,
-      reaction: reaction
-    } do
-      Repo.delete(user)
-
-      assert Repo.reload(chat_session)
-      assert Repo.reload(message)
-
-      reaction = Repo.reload(reaction)
-      assert reaction.message_id
-      refute reaction.user_id
     end
   end
 end

--- a/test/exmeralda/chats/session_test.exs
+++ b/test/exmeralda/chats/session_test.exs
@@ -40,19 +40,26 @@ defmodule Exmeralda.Chats.SessionTest do
       user = insert(:user)
       ingestion = insert(:ingestion)
       chat_session = insert(:chat_session, user: user, ingestion: ingestion)
+      message = insert(:message, session: chat_session)
+      reaction = insert(:reaction, message: message)
 
-      %{user: user, chat_session: chat_session}
+      %{user: user, chat_session: chat_session, message: message, reaction: reaction}
     end
 
     test "user is nilified on deletion of the user", %{
       user: user,
-      chat_session: chat_session
+      chat_session: chat_session,
+      message: message,
+      reaction: reaction
     } do
       Repo.delete(user)
 
       chat_session = Repo.reload(chat_session)
       assert chat_session
       refute chat_session.user_id
+
+      assert Repo.reload(message)
+      assert Repo.reload(reaction)
     end
   end
 end

--- a/test/exmeralda/chats/session_test.exs
+++ b/test/exmeralda/chats/session_test.exs
@@ -34,4 +34,25 @@ defmodule Exmeralda.Chats.SessionTest do
       |> assert_changes(:title, sliced_prompt)
     end
   end
+
+  describe "nilify behaviour" do
+    setup do
+      user = insert(:user)
+      ingestion = insert(:ingestion)
+      chat_session = insert(:chat_session, user: user, ingestion: ingestion)
+
+      %{user: user, chat_session: chat_session}
+    end
+
+    test "user is nilified on deletion of the user", %{
+      user: user,
+      chat_session: chat_session
+    } do
+      Repo.delete(user)
+
+      chat_session = Repo.reload(chat_session)
+      assert chat_session
+      refute chat_session.user_id
+    end
+  end
 end

--- a/test/exmeralda/chats_test.exs
+++ b/test/exmeralda/chats_test.exs
@@ -216,11 +216,26 @@ defmodule Exmeralda.ChatsTest do
     end
   end
 
-  describe "unlink_user_from_session!/1" do
+  describe "unlink_user_from_session/2 when the session does not exist" do
+    test "returns an error" do
+      assert Chats.unlink_user_from_session(uuid(), uuid()) == {:error, {:not_found, Session}}
+    end
+  end
+
+  describe "unlink_user_from_session/2 when the session does belong to the user" do
+    test "returns an error" do
+      user = insert(:user)
+      session = insert(:chat_session, user: user)
+      assert Chats.unlink_user_from_session(uuid(), session.id) == {:error, {:not_found, Session}}
+      assert Repo.reload(session).user_id
+    end
+  end
+
+  describe "unlink_user_from_session/2" do
     test "unsets used_id on the session" do
       user = insert(:user)
       session = insert(:chat_session, user: user)
-      assert updated_session = Chats.unlink_user_from_session!(session)
+      assert {:ok, updated_session} = Chats.unlink_user_from_session(user.id, session.id)
       refute updated_session.user_id
     end
   end

--- a/test/exmeralda/chats_test.exs
+++ b/test/exmeralda/chats_test.exs
@@ -277,15 +277,15 @@ defmodule Exmeralda.ChatsTest do
   end
 
   describe "delete_reaction/1 when the reaction does not exist" do
-    test "returns an error" do
-      assert Chats.delete_reaction(uuid()) == {:error, {:not_found, Reaction}}
+    test "returns ok" do
+      assert Chats.delete_reaction(uuid()) == :ok
     end
   end
 
   describe "delete_reaction/1" do
     test "deletes the reaction" do
       reaction = insert(:reaction)
-      assert {:ok, _} = Chats.delete_reaction(reaction.id)
+      assert Chats.delete_reaction(reaction.id) == :ok
       refute Repo.reload(reaction)
     end
   end

--- a/test/exmeralda/chats_test.exs
+++ b/test/exmeralda/chats_test.exs
@@ -212,4 +212,25 @@ defmodule Exmeralda.ChatsTest do
       assert {:ok, _} = Chats.delete_session(session)
     end
   end
+
+  defp create_user_and_session(_context) do
+    user = insert(:user)
+    session = insert(:chat_session, user: user)
+
+    %{user: user, session: session}
+  end
+
+  defp create_message(%{session: session}) do
+    message = insert(:message, session: session)
+
+    %{message: message}
+  end
+
+  describe "create_reaction/3" do
+    setup [:create_user_and_session, :create_message]
+
+    test "creates new reaction for message and user", %{message: message, user: user} do
+      assert {:ok, _reaction} = Chats.create_reaction(message, user, :upvote)
+    end
+  end
 end

--- a/test/exmeralda_web/live/admin/library_live_test.exs
+++ b/test/exmeralda_web/live/admin/library_live_test.exs
@@ -44,8 +44,9 @@ defmodule ExmeraldaWeb.Admin.LibraryLiveTest do
     test "delete a library, its ingestion and chats", %{conn: conn, user: user, library: library} do
       ingestion = insert(:ingestion, library: library)
       chunk = insert(:chunk, ingestion: ingestion, library: library)
-      session = insert(:chat_session, ingestion: ingestion)
-      message = insert(:message, session: session)
+      # TODO: [EX-93] Delete an ingestion or a library only when no chat sessions exist
+      # session = insert(:chat_session, ingestion: ingestion)
+      # message = insert(:message, session: session)
 
       conn = log_in_user(conn, user)
 
@@ -60,8 +61,8 @@ defmodule ExmeraldaWeb.Admin.LibraryLiveTest do
 
       refute Repo.reload(library)
       refute Repo.reload(ingestion)
-      refute Repo.reload(session)
-      refute Repo.reload(message)
+      # refute Repo.reload(session)
+      # refute Repo.reload(message)
       refute Repo.reload(chunk)
     end
 

--- a/test/exmeralda_web/live/chat_live_test.exs
+++ b/test/exmeralda_web/live/chat_live_test.exs
@@ -6,7 +6,7 @@ defmodule ExmeraldaWeb.ChatLiveTest do
   alias Exmeralda.Chats.{Reaction, Session}
 
   defp insert_library(_) do
-    library = insert(:library)
+    library = insert(:library, name: "ecto")
     ingestion = insert(:ingestion, library: library, state: :ready)
 
     %{library: library, ingestion: ingestion}

--- a/test/exmeralda_web/live/chat_live_test.exs
+++ b/test/exmeralda_web/live/chat_live_test.exs
@@ -148,7 +148,6 @@ defmodule ExmeraldaWeb.ChatLiveTest do
       assert chat_live |> element(".e2e-upvote-message-#{message.id}") |> render_click()
 
       [reaction] = Repo.all(Reaction)
-      assert reaction.user_id == user.id
       assert reaction.message_id == message.id
       assert reaction.type == :upvote
 

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -20,6 +20,7 @@ defmodule Exmeralda.Factory do
 
   def reaction_factory do
     %Exmeralda.Chats.Reaction{
+      ingestion: build(:ingestion),
       message: build(:message),
       user: build(:user),
       type: :upvote

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -21,7 +21,6 @@ defmodule Exmeralda.Factory do
   def reaction_factory do
     %Exmeralda.Chats.Reaction{
       message: build(:message),
-      user: build(:user),
       type: :upvote
     }
   end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -20,7 +20,6 @@ defmodule Exmeralda.Factory do
 
   def reaction_factory do
     %Exmeralda.Chats.Reaction{
-      ingestion: build(:ingestion),
       message: build(:message),
       user: build(:user),
       type: :upvote

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -18,6 +18,14 @@ defmodule Exmeralda.Factory do
     }
   end
 
+  def reaction_factory do
+    %Exmeralda.Chats.Reaction{
+      message: build(:message),
+      user: build(:user),
+      type: :upvote
+    }
+  end
+
   def user_factory do
     %Exmeralda.Accounts.User{
       name: "Evil Rick",


### PR DESCRIPTION
The PR introduces a reaction system so that users can upvote or downvote an answer from the assistant. Because the goal is to gather enough data to make decisions/analytics on the ingestion quality, we change the `on_delete` triggers to prevent deletion of sessions, messages and reactions. 

As such, deleting a chat session or a user account only nilifies the user ID on the chat sessions.

Looks like:

<img width="925" height="858" alt="image" src="https://github.com/user-attachments/assets/ad6082c3-106d-4b72-9723-ee14f2e76500" />
