### PR TITLE
[EX-89] Allow admins to set the active ingestion for a package

### DIFF
--- a/lib/exmeralda/topics.ex
+++ b/lib/exmeralda/topics.ex
@@ -348,7 +348,13 @@ defmodule Exmeralda.Topics do
         :ok
     end
 
-    ingestion |> Ingestion.set_ingestion_active_changeset() |> Repo.update()
+    {:ok, mark_ingestion_as_active!(ingestion)}
+  end
+
+  def mark_ingestion_as_active!(ingestion) do
+    ingestion
+    |> Ingestion.set_ingestion_active_changeset()
+    |> Repo.update!()
   end
 
   @spec mark_ingestion_as_inactive(Ingestion.id()) ::

--- a/lib/exmeralda/topics.ex
+++ b/lib/exmeralda/topics.ex
@@ -351,7 +351,7 @@ defmodule Exmeralda.Topics do
     {:ok, mark_ingestion_as_active!(ingestion)}
   end
 
-  def mark_ingestion_as_active!(ingestion) do
+  defp mark_ingestion_as_active!(ingestion) do
     ingestion
     |> Ingestion.set_ingestion_active_changeset()
     |> Repo.update!()

--- a/lib/exmeralda/topics/generate_embeddings_worker.ex
+++ b/lib/exmeralda/topics/generate_embeddings_worker.ex
@@ -49,9 +49,8 @@ defmodule Exmeralda.Topics.GenerateEmbeddingsWorker do
         |> Enum.each(&Repo.update!/1)
 
         if all_chunks_embedded?(ingestion.id) do
-          ingestion
-          |> Topics.update_ingestion_state!(:ready)
-          |> Topics.mark_ingestion_as_active!()
+          ingestion = Topics.update_ingestion_state!(ingestion, :ready)
+          {:ok, _} = Topics.mark_ingestion_as_active(ingestion.id)
         end
 
         {:ok, ingestion}

--- a/lib/exmeralda/topics/generate_embeddings_worker.ex
+++ b/lib/exmeralda/topics/generate_embeddings_worker.ex
@@ -49,7 +49,9 @@ defmodule Exmeralda.Topics.GenerateEmbeddingsWorker do
         |> Enum.each(&Repo.update!/1)
 
         if all_chunks_embedded?(ingestion.id) do
-          Topics.update_ingestion_state!(ingestion, :ready)
+          ingestion
+          |> Topics.update_ingestion_state!(:ready)
+          |> Topics.mark_ingestion_as_active!()
         end
 
         {:ok, ingestion}

--- a/lib/exmeralda/topics/ingestion.ex
+++ b/lib/exmeralda/topics/ingestion.ex
@@ -50,4 +50,12 @@ defmodule Exmeralda.Topics.Ingestion do
   def set_ingestion_job_id(ingestion, job_id) do
     change(ingestion, job_id: job_id)
   end
+
+  def set_ingestion_inactive_changeset(ingestion) do
+    change(ingestion, active: false)
+  end
+
+  def set_ingestion_active_changeset(ingestion) do
+    change(ingestion, active: true)
+  end
 end

--- a/lib/exmeralda/topics/ingestion.ex
+++ b/lib/exmeralda/topics/ingestion.ex
@@ -17,11 +17,12 @@ defmodule Exmeralda.Topics.Ingestion do
   }
 
   schema "ingestions" do
-    field :state, Ecto.Enum, values: [:queued, :embedding, :failed, :ready]
-
     belongs_to :library, Library
     has_many :chunks, Chunk
     belongs_to :job, Oban.Job, foreign_key: :job_id, type: :integer
+
+    field :state, Ecto.Enum, values: [:queued, :embedding, :failed, :ready]
+    field :active, :boolean, default: false
 
     timestamps()
   end

--- a/lib/exmeralda_web/live/admin/helper.ex
+++ b/lib/exmeralda_web/live/admin/helper.ex
@@ -100,7 +100,7 @@ defmodule ExmeraldaWeb.Admin.Helper do
   def ingestion_active_badge(assigns) do
     ~H"""
     <div :if={@active} class="tooltip" data-tip={gettext("New chat sessions use this ingestion.")}>
-      <span class="badge badge-success badge-soft mr-2 mt-2 lg:mt-0 lg:ml-4">
+      <span class="badge badge-success mr-2 mt-2 lg:mt-0 lg:ml-4">
         <.icon name="hero-check-circle-micro" class="scale-75" />
         {gettext("Active")}
       </span>
@@ -110,7 +110,7 @@ defmodule ExmeraldaWeb.Admin.Helper do
       class="tooltip"
       data-tip={gettext("New chat sessions do not use this ingestion.")}
     >
-      <span class="badge badge-warning badge-soft ml-4">
+      <span class="badge badge-warning ml-4">
         <.icon name="hero-no-symbol-micro" class="scale-75" />
         {gettext("Inactive")}
       </span>

--- a/lib/exmeralda_web/live/admin/helper.ex
+++ b/lib/exmeralda_web/live/admin/helper.ex
@@ -96,4 +96,25 @@ defmodule ExmeraldaWeb.Admin.Helper do
         gettext("Done!")
     end
   end
+
+  def ingestion_active_badge(assigns) do
+    ~H"""
+    <div :if={@active} class="tooltip" data-tip={gettext("New chat sessions use this ingestion.")}>
+      <span class="badge badge-success badge-soft mr-2 mt-2 lg:mt-0 lg:ml-4">
+        <.icon name="hero-check-circle-micro" class="scale-75" />
+        {gettext("Active")}
+      </span>
+    </div>
+    <div
+      :if={!@active}
+      class="tooltip"
+      data-tip={gettext("New chat sessions do not use this ingestion.")}
+    >
+      <span class="badge badge-warning badge-soft ml-4">
+        <.icon name="hero-no-symbol-micro" class="scale-75" />
+        {gettext("Inactive")}
+      </span>
+    </div>
+    """
+  end
 end

--- a/lib/exmeralda_web/live/admin/ingestion_live/show.ex
+++ b/lib/exmeralda_web/live/admin/ingestion_live/show.ex
@@ -78,7 +78,7 @@ defmodule ExmeraldaWeb.Admin.IngestionLive.Show do
       </.breadcrumbs>
 
       <.header title={"Ingestion ##{@ingestion.id} for #{library_title(@library)}"}>
-        <.ingestion_state_badge state={@ingestion.state} />
+        <.ingestion_active_badge active={@ingestion.active} />
         <:actions>
           <div
             class={[!@ingestion_deletable? && "tooltip tooltip-left"]}
@@ -98,6 +98,7 @@ defmodule ExmeraldaWeb.Admin.IngestionLive.Show do
 
       <.list>
         <:item title={gettext("ID")}>{@ingestion.id}</:item>
+        <:item title={gettext("State")}><.ingestion_state_badge state={@ingestion.state} /></:item>
         <:item title={gettext("Current Oban Job")}>
           <%= if @ingestion.job_id do %>
             <div>

--- a/lib/exmeralda_web/live/admin/library_live/show.ex
+++ b/lib/exmeralda_web/live/admin/library_live/show.ex
@@ -201,21 +201,21 @@ defmodule ExmeraldaWeb.Admin.LibraryLive.Show do
             </.link>
             <.button
               :if={ingestion.state == :ready && !ingestion.active}
-              class="btn btn-primary btn-soft btn-sm ml-2"
+              class="btn btn-primary btn-soft btn-sm mt-1 lg:mt-0 lg:ml-2"
               phx-click="mark-as-active"
               phx-value-ingestion-id={ingestion.id}
             >
               <.icon name="hero-check-circle-micro" class="scale-75" />
-              {gettext("Mark as active")}
+              {gettext("Activate")}
             </.button>
             <.button
               :if={ingestion.state == :ready && ingestion.active}
-              class="btn btn-secondary btn-soft btn-sm ml-2"
+              class="btn btn-outline btn-dash btn-sm mt-1 lg:mt-0 lg:ml-2"
               phx-click="mark-as-inactive"
               phx-value-ingestion-id={ingestion.id}
             >
               <.icon name="hero-no-symbol-micro" class="scale-75" />
-              {gettext("Mark as inactive")}
+              {gettext("Deactivate")}
             </.button>
           </:col>
         </Flop.Phoenix.table>

--- a/lib/exmeralda_web/live/admin/library_live/show.ex
+++ b/lib/exmeralda_web/live/admin/library_live/show.ex
@@ -135,7 +135,10 @@ defmodule ExmeraldaWeb.Admin.LibraryLive.Show do
           path={~p"/admin/library/#{@library.id}"}
           opts={[table_attrs: [class: "table"]]}
         >
-          <:col :let={ingestion} label="ID" field={:id}>{ingestion.id}</:col>
+          <:col :let={ingestion} label="ID" field={:id}>
+            {ingestion.id}
+            <.ingestion_active_badge :if={ingestion.active} active={ingestion.active} />
+          </:col>
           <:col :let={ingestion} label="State" field={:state}>
             <.ingestion_state_badge state={ingestion.state} />
           </:col>

--- a/lib/exmeralda_web/live/admin/library_live/show.ex
+++ b/lib/exmeralda_web/live/admin/library_live/show.ex
@@ -65,6 +65,27 @@ defmodule ExmeraldaWeb.Admin.LibraryLive.Show do
     {:noreply, socket}
   end
 
+  def handle_event("mark-as-active", %{"ingestion-id" => ingestion_id}, socket) do
+    %{library: library} = socket.assigns
+    socket =
+      case Topics.mark_ingestion_as_active(ingestion_id) do
+        {:ok, ingestion} ->
+          socket
+          |> put_flash(:info, gettext("Ingestion was successfully marked active."))
+          |> push_patch(to: ~p"/admin/library/#{library.id}")
+
+        {:error, error} when error in [:ingestion_already_active, :ingestion_invalid_state] ->
+          push_patch(socket, to: ~p"/admin/library/#{library.id}")
+
+        {:error, {:not_found, _}} ->
+          socket
+          |> put_flash(:error, gettext("Ingestion was deleted and cannot be marked active."))
+          |> push_patch(to: ~p"/admin/library/#{library.id}")
+      end
+
+    {:noreply, socket}
+  end
+
   @impl true
   def render(assigns) do
     assigns = assign_new(assigns, :library_deletable?, fn -> library_deletable?(assigns) end)
@@ -155,6 +176,15 @@ defmodule ExmeraldaWeb.Admin.LibraryLive.Show do
             >
               Show
             </.link>
+            <.button
+              :if={ingestion.state == :ready && !ingestion.active}
+              class="btn btn-primary btn-soft btn-sm ml-2"
+              phx-click="mark-as-active"
+              phx-value-ingestion-id={ingestion.id}
+            >
+              <.icon name="hero-check-circle-micro" class="scale-75" />
+              {gettext("Mark as active")}
+            </.button>
           </:col>
         </Flop.Phoenix.table>
 

--- a/lib/exmeralda_web/live/admin/library_live/show.ex
+++ b/lib/exmeralda_web/live/admin/library_live/show.ex
@@ -70,7 +70,7 @@ defmodule ExmeraldaWeb.Admin.LibraryLive.Show do
 
     socket =
       case Topics.mark_ingestion_as_active(ingestion_id) do
-        {:ok, ingestion} ->
+        {:ok, _ingestion} ->
           socket
           |> put_flash(:info, gettext("Ingestion was successfully marked active."))
           |> push_patch(to: ~p"/admin/library/#{library.id}")
@@ -92,7 +92,7 @@ defmodule ExmeraldaWeb.Admin.LibraryLive.Show do
 
     socket =
       case Topics.mark_ingestion_as_inactive(ingestion_id) do
-        {:ok, ingestion} ->
+        {:ok, _ingestion} ->
           socket
           |> put_flash(:info, gettext("Ingestion was successfully marked inactive."))
           |> push_patch(to: ~p"/admin/library/#{library.id}")

--- a/lib/exmeralda_web/live/admin/library_live/show.ex
+++ b/lib/exmeralda_web/live/admin/library_live/show.ex
@@ -201,7 +201,7 @@ defmodule ExmeraldaWeb.Admin.LibraryLive.Show do
             </.link>
             <.button
               :if={ingestion.state == :ready && !ingestion.active}
-              class="btn btn-primary btn-soft btn-sm mt-1 lg:mt-0 lg:ml-2"
+              class={"btn btn-primary btn-soft btn-sm mt-1 lg:mt-0 lg:ml-2 e2e-activate-#{ingestion.id}"}
               phx-click="mark-as-active"
               phx-value-ingestion-id={ingestion.id}
             >
@@ -210,7 +210,7 @@ defmodule ExmeraldaWeb.Admin.LibraryLive.Show do
             </.button>
             <.button
               :if={ingestion.state == :ready && ingestion.active}
-              class="btn btn-outline btn-dash btn-sm mt-1 lg:mt-0 lg:ml-2"
+              class={"btn btn-outline btn-dash btn-sm mt-1 lg:mt-0 lg:ml-2 e2e-deactivate-#{ingestion.id}"}
               phx-click="mark-as-inactive"
               phx-value-ingestion-id={ingestion.id}
             >

--- a/lib/exmeralda_web/live/chat_live/ingestions/index.ex
+++ b/lib/exmeralda_web/live/chat_live/ingestions/index.ex
@@ -38,11 +38,8 @@ defmodule ExmeraldaWeb.ChatLive.Ingestions.Index do
     socket =
       socket
       |> assign(:page_title, "Latest Library Updates")
-      |> assign(
-        :ongoing_ingestions,
-        Topics.last_ingestions([:queued, :embedding])
-      )
-      |> assign(:ready_ingestions, Topics.last_ingestions([:ready, :failed]))
+      |> assign(:ongoing_ingestions, Topics.last_ongoing_ingestions())
+      |> assign(:ready_ingestions, Topics.last_ready_ingestions())
 
     {:ok, socket}
   end

--- a/lib/exmeralda_web/live/chat_live/start_chat.ex
+++ b/lib/exmeralda_web/live/chat_live/start_chat.ex
@@ -104,17 +104,17 @@ defmodule ExmeraldaWeb.ChatLive.StartChat do
     %{selected_library: library} = socket.assigns
 
     case Topics.active_ingestion(library.id) do
-      nil ->
+      {:ok, active_ingestion} ->
+        do_start_session(socket, session_params, active_ingestion)
+
+      {:error, {:not_found, _}} ->
         {:noreply,
          socket
          |> put_flash(
            :error,
-           gettext("This library cannot be used anymore! Try adding it again.")
+           gettext("This library cannot be used anymore.")
          )
          |> push_navigate(to: ~p"/chat/start")}
-
-      active_ingestion ->
-        do_start_session(socket, session_params, active_ingestion)
     end
   end
 

--- a/lib/exmeralda_web/live/chat_live/start_chat.ex
+++ b/lib/exmeralda_web/live/chat_live/start_chat.ex
@@ -103,7 +103,7 @@ defmodule ExmeraldaWeb.ChatLive.StartChat do
   def handle_event("start", %{"session" => session_params}, socket) do
     %{selected_library: library} = socket.assigns
 
-    case Topics.current_ingestion(library) do
+    case Topics.active_ingestion(library.id) do
       nil ->
         {:noreply,
          socket
@@ -113,8 +113,8 @@ defmodule ExmeraldaWeb.ChatLive.StartChat do
          )
          |> push_navigate(to: ~p"/chat/start")}
 
-      current_ingestion ->
-        do_start_session(socket, session_params, current_ingestion)
+      active_ingestion ->
+        do_start_session(socket, session_params, active_ingestion)
     end
   end
 
@@ -151,13 +151,13 @@ defmodule ExmeraldaWeb.ChatLive.StartChat do
 
   defp notify_parent(msg), do: send(self(), {__MODULE__, msg})
 
-  defp do_start_session(socket, session_params, current_ingestion) do
+  defp do_start_session(socket, session_params, active_ingestion) do
     %{user: user, selected_library: library} = socket.assigns
 
     params =
       Map.merge(session_params, %{
-        "ingestion_id" => current_ingestion.id,
-        "library_id" => current_ingestion.library_id
+        "ingestion_id" => active_ingestion.id,
+        "library_id" => active_ingestion.library_id
       })
 
     case Chats.start_session(user, params) do

--- a/lib/exmeralda_web/live/shared/helper.ex
+++ b/lib/exmeralda_web/live/shared/helper.ex
@@ -16,6 +16,27 @@ defmodule ExmeraldaWeb.Shared.Helper do
   defp ingestion_state_class(:queued), do: "badge-info"
   defp ingestion_state_class(_), do: "badge-warning"
 
+  def ingestion_active_badge(assigns) do
+    ~H"""
+    <div :if={@active} class="tooltip" data-tip={gettext("New chat sessions use this ingestion.")}>
+      <span class="badge badge-success badge-soft ml-4">
+        <.icon name="hero-check-circle-micro" class="scale-75" />
+        {gettext("Active")}
+      </span>
+    </div>
+    <div
+      :if={!@active}
+      class="tooltip"
+      data-tip={gettext("New chat sessions do not use this ingestion.")}
+    >
+      <span class="badge badge-warning badge-soft ml-4">
+        <.icon name="hero-no-symbol-micro" class="scale-75" />
+        {gettext("Inactive")}
+      </span>
+    </div>
+    """
+  end
+
   # credo:disable-for-lines:20 Credo.Check.Refactor.CyclomaticComplexity
   def find_current_step(%{state: :queued, job: %{state: state}})
       when state in ["scheduled", "available"],

--- a/lib/exmeralda_web/live/shared/helper.ex
+++ b/lib/exmeralda_web/live/shared/helper.ex
@@ -5,7 +5,7 @@ defmodule ExmeraldaWeb.Shared.Helper do
 
   def ingestion_state_badge(assigns) do
     ~H"""
-    <span class={["badge", ingestion_state_class(@state)]}>
+    <span class={["badge badge-soft", ingestion_state_class(@state)]}>
       {@state}
     </span>
     """

--- a/lib/exmeralda_web/live/shared/helper.ex
+++ b/lib/exmeralda_web/live/shared/helper.ex
@@ -16,27 +16,6 @@ defmodule ExmeraldaWeb.Shared.Helper do
   defp ingestion_state_class(:queued), do: "badge-info"
   defp ingestion_state_class(_), do: "badge-warning"
 
-  def ingestion_active_badge(assigns) do
-    ~H"""
-    <div :if={@active} class="tooltip" data-tip={gettext("New chat sessions use this ingestion.")}>
-      <span class="badge badge-success badge-soft ml-4">
-        <.icon name="hero-check-circle-micro" class="scale-75" />
-        {gettext("Active")}
-      </span>
-    </div>
-    <div
-      :if={!@active}
-      class="tooltip"
-      data-tip={gettext("New chat sessions do not use this ingestion.")}
-    >
-      <span class="badge badge-warning badge-soft ml-4">
-        <.icon name="hero-no-symbol-micro" class="scale-75" />
-        {gettext("Inactive")}
-      </span>
-    </div>
-    """
-  end
-
   # credo:disable-for-lines:20 Credo.Check.Refactor.CyclomaticComplexity
   def find_current_step(%{state: :queued, job: %{state: state}})
       when state in ["scheduled", "available"],

--- a/priv/repo/migrations/20250821085115_add_active_to_ingestions.exs
+++ b/priv/repo/migrations/20250821085115_add_active_to_ingestions.exs
@@ -19,6 +19,14 @@ defmodule Exmeralda.Repo.Migrations.AddActiveToIngestions do
     """)
 
     create unique_index(:ingestions, [:library_id, :active], where: "active IS TRUE")
+
+    create(
+      constraint(
+        :ingestions,
+        :active_when_ready,
+        check: "NOT (active IS TRUE AND state != 'ready')"
+      )
+    )
   end
 
   def down do

--- a/priv/repo/migrations/20250821085115_add_active_to_ingestions.exs
+++ b/priv/repo/migrations/20250821085115_add_active_to_ingestions.exs
@@ -1,0 +1,28 @@
+defmodule Exmeralda.Repo.Migrations.AddActiveToIngestions do
+  use Ecto.Migration
+
+  def up do
+    alter table(:ingestions) do
+      add :active, :boolean, default: false, null: false
+    end
+
+    execute("""
+      UPDATE ingestions
+      SET active = TRUE
+      FROM (
+        SELECT DISTINCT ON (library_id) *
+        FROM ingestions
+        ORDER BY library_id, inserted_at DESC
+      ) AS subquery
+      WHERE ingestions.id = subquery.id;
+    """)
+
+    create unique_index(:ingestions, [:library_id, :active], where: "active IS TRUE")
+  end
+
+  def down do
+    alter table(:ingestions) do
+      remove :active
+    end
+  end
+end

--- a/priv/repo/migrations/20250821085115_add_active_to_ingestions.exs
+++ b/priv/repo/migrations/20250821085115_add_active_to_ingestions.exs
@@ -12,6 +12,7 @@ defmodule Exmeralda.Repo.Migrations.AddActiveToIngestions do
       FROM (
         SELECT DISTINCT ON (library_id) *
         FROM ingestions
+        WHERE state = 'ready'
         ORDER BY library_id, inserted_at DESC
       ) AS subquery
       WHERE ingestions.id = subquery.id;

--- a/priv/repo/seeds.exs
+++ b/priv/repo/seeds.exs
@@ -36,6 +36,6 @@ libraries = [
 ]
 
 for library <- libraries do
-  ingestion = insert(:ingestion, library: library, state: :ready)
+  ingestion = insert(:ingestion, library: library, state: :ready, active: true)
   insert(:chunk, library: library, ingestion: ingestion)
 end

--- a/test/exmeralda/topics/generate_embeddings_worker_test.exs
+++ b/test/exmeralda/topics/generate_embeddings_worker_test.exs
@@ -88,7 +88,7 @@ defmodule Exmeralda.Topics.GenerateEmbeddingsWorkerTest do
       library: library,
       ingestion: ingestion
     } do
-      insert(:ingestion, library: library, active: true, state: :ready)
+      active_ingestion = insert(:ingestion, library: library, active: true, state: :ready)
 
       assert :ok =
                perform_job(GenerateEmbeddingsWorker, %{
@@ -102,6 +102,9 @@ defmodule Exmeralda.Topics.GenerateEmbeddingsWorkerTest do
 
       assert ingestion.state == :ready
       assert ingestion.active
+
+      active_ingestion = Repo.reload(active_ingestion)
+      refute active_ingestion.active
     end
   end
 

--- a/test/exmeralda/topics/generate_embeddings_worker_test.exs
+++ b/test/exmeralda/topics/generate_embeddings_worker_test.exs
@@ -84,7 +84,7 @@ defmodule Exmeralda.Topics.GenerateEmbeddingsWorkerTest do
       refute from(c in Chunk, where: is_nil(c.embedding)) |> Repo.one()
     end
 
-    test "sets ingestion state to :ready when all chunks embedded", %{
+    test "activates and sets ingestion state to :ready when all chunks embedded", %{
       library: library,
       ingestion: ingestion
     } do
@@ -99,6 +99,7 @@ defmodule Exmeralda.Topics.GenerateEmbeddingsWorkerTest do
       ingestion = Repo.reload(ingestion)
 
       assert ingestion.state == :ready
+      assert ingestion.active
     end
   end
 
@@ -174,6 +175,7 @@ defmodule Exmeralda.Topics.GenerateEmbeddingsWorkerTest do
       # and the ingestion has failed
       ingestion = Repo.reload(ingestion)
       assert ingestion.state == :failed
+      refute ingestion.active
     end
   end
 

--- a/test/exmeralda/topics/generate_embeddings_worker_test.exs
+++ b/test/exmeralda/topics/generate_embeddings_worker_test.exs
@@ -88,6 +88,8 @@ defmodule Exmeralda.Topics.GenerateEmbeddingsWorkerTest do
       library: library,
       ingestion: ingestion
     } do
+      insert(:ingestion, library: library, active: true, state: :ready)
+
       assert :ok =
                perform_job(GenerateEmbeddingsWorker, %{
                  library_id: library.id,

--- a/test/exmeralda/topics/ingestion_test.exs
+++ b/test/exmeralda/topics/ingestion_test.exs
@@ -31,4 +31,22 @@ defmodule Exmeralda.Topics.IngestionTest do
       |> refute_changeset_valid()
     end
   end
+
+  describe "set_ingestion_inactive_changeset/1" do
+    test "sets active to false" do
+      build(:ingestion, active: true)
+      |> Ingestion.set_ingestion_inactive_changeset()
+      |> assert_changeset_valid()
+      |> assert_changes(:active, false)
+    end
+  end
+
+  describe "set_ingestion_active_changeset/1" do
+    test "sets active to true" do
+      build(:ingestion, active: false)
+      |> Ingestion.set_ingestion_active_changeset()
+      |> assert_changeset_valid()
+      |> assert_changes(:active, true)
+    end
+  end
 end

--- a/test/exmeralda/topics/ingestion_test.exs
+++ b/test/exmeralda/topics/ingestion_test.exs
@@ -2,6 +2,18 @@ defmodule Exmeralda.Topics.IngestionTest do
   use Exmeralda.DataCase
   alias Exmeralda.Topics.Ingestion
 
+  describe "table" do
+    test "active_when_ready constraint" do
+      insert(:ingestion, active: true, state: :ready)
+      insert(:ingestion, active: false, state: :ready)
+      insert(:ingestion, active: false, state: :queued)
+
+      assert_raise Ecto.ConstraintError, ~r/active_when_ready/, fn ->
+        insert(:ingestion, active: true, state: :queued)
+      end
+    end
+  end
+
   describe "changeset/2" do
     test "works" do
       %{state: :queued, library_id: uuid()}

--- a/test/exmeralda/topics_test.exs
+++ b/test/exmeralda/topics_test.exs
@@ -94,7 +94,10 @@ defmodule Exmeralda.TopicsTest do
 
     test "returns the active ingestion if present", %{library: library} do
       active_ingestion = insert(:ingestion, state: :ready, active: true, library: library)
-      _other_library_ingestion = insert(:ingestion, library: insert(:library), active: true)
+
+      _other_library_ingestion =
+        insert(:ingestion, library: insert(:library), active: true, state: :ready)
+
       _other_ingestion = insert(:ingestion, library: library, active: false)
 
       assert {:ok, ingestion} = Topics.active_ingestion(library.id)

--- a/test/exmeralda_web/live/chat_live_test.exs
+++ b/test/exmeralda_web/live/chat_live_test.exs
@@ -7,7 +7,7 @@ defmodule ExmeraldaWeb.ChatLiveTest do
 
   defp insert_library(_) do
     library = insert(:library, name: "ecto")
-    ingestion = insert(:ingestion, library: library, state: :ready)
+    ingestion = insert(:ingestion, library: library, state: :ready, active: true)
 
     %{library: library, ingestion: ingestion}
   end


### PR DESCRIPTION
The PR introduces a concept of "active" state on an ingestion. 

- Only one maximum ingestion per library can be active at a time
- When a new ingestion is created (first one, or after being re-ingested), it is set as active
- Admins can manually change which ingestion is the active one for a library
- A library can have all of its ingestion inactive, in which case it is not listed among the libraries a user can chat with

Looks like:

<img width="1710" height="340" alt="image" src="https://github.com/user-attachments/assets/dfcf5a8b-01a2-442c-9e1f-8ff01a5320f6" />


