### PR TITLE
[EX-70] Store prompts in database

### DIFF
--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -95,7 +95,8 @@ cond do
       llm_config: %{
         # The CURRENT_LLM_MODEL_CONFIG_PROVIDER_ID must match an existing ModelConfigProvider record in the database
         model_config_provider_id: System.fetch_env!("CURRENT_LLM_MODEL_CONFIG_PROVIDER_ID"),
-        system_prompt_id: System.fetch_env!("CURRENT_LLM_SYSTEM_PROMPT_ID")
+        system_prompt_id: System.fetch_env!("CURRENT_LLM_SYSTEM_PROMPT_ID"),
+        generation_prompt_id: System.fetch_env!("CURRENT_RAG_GENERATION_PROMPT_ID")
       }
 
   config_env() == :dev ->
@@ -104,7 +105,8 @@ cond do
       # Points to the Ollama dev config set in the seeds
       llm_config: %{
         model_config_provider_id: "1f0e49ff-a985-4c03-a89b-fa443842fa95",
-        system_prompt_id: "c49195b4-daca-42af-835d-bdb928986d5c"
+        system_prompt_id: "c49195b4-daca-42af-835d-bdb928986d5c",
+        generation_prompt_id: "3ef5b20b-bb71-467d-8364-898df9926a95"
       }
 
   true ->
@@ -113,7 +115,8 @@ cond do
       llm_config: %{
         # Random IDs that is used in the tests!
         model_config_provider_id: "9a21bfd3-cb0a-433c-a9b3-826143782c81",
-        system_prompt_id: "96123e4b-7d0a-4e14-82d4-63d68562e8f1"
+        system_prompt_id: "96123e4b-7d0a-4e14-82d4-63d68562e8f1",
+        generation_prompt_id: "a6dd3ab3-d57e-43d9-a39a-d1ce58a43cc0"
       }
 end
 

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -94,7 +94,8 @@ cond do
       },
       llm_config: %{
         # The CURRENT_LLM_MODEL_CONFIG_PROVIDER_ID must match an existing ModelConfigProvider record in the database
-        model_config_provider_id: System.fetch_env!("CURRENT_LLM_MODEL_CONFIG_PROVIDER_ID")
+        model_config_provider_id: System.fetch_env!("CURRENT_LLM_MODEL_CONFIG_PROVIDER_ID"),
+        system_prompt_id: System.fetch_env!("CURRENT_LLM_SYSTEM_PROMPT_ID")
       }
 
   config_env() == :dev ->
@@ -102,7 +103,8 @@ cond do
       llm_api_keys: %{},
       # Points to the Ollama dev config set in the seeds
       llm_config: %{
-        model_config_provider_id: "1f0e49ff-a985-4c03-a89b-fa443842fa95"
+        model_config_provider_id: "1f0e49ff-a985-4c03-a89b-fa443842fa95",
+        system_prompt_id: "c49195b4-daca-42af-835d-bdb928986d5c"
       }
 
   true ->
@@ -110,7 +112,8 @@ cond do
       llm_api_keys: %{"foo_ai" => "abcde"},
       llm_config: %{
         # Random IDs that is used in the tests!
-        model_config_provider_id: "9a21bfd3-cb0a-433c-a9b3-826143782c81"
+        model_config_provider_id: "9a21bfd3-cb0a-433c-a9b3-826143782c81",
+        system_prompt_id: "96123e4b-7d0a-4e14-82d4-63d68562e8f1"
       }
 end
 
@@ -134,24 +137,6 @@ cond do
   true ->
     config :exmeralda, :embedding, Exmeralda.Rag.Fake
 end
-
-config :exmeralda,
-       :system_prompt,
-       """
-       You are an expert in Elixir programming with in-depth knowledge of Elixir.
-       Provide accurate information based on the provided context to assist Elixir
-       developers. Include code snippets and examples to illustrate your points.
-       Respond in a professional yet approachable manner.
-       Be concise for straightforward queries, but elaborate when necessary to
-       ensure clarity and understanding. Adapt your responses to the complexity of
-       the question. For basic usage, provide clear examples. For advanced topics,
-       offer detailed explanations and multiple solutions if applicable.
-       Include references to official documentation or reliable sources to support
-       your answers. Ensure information is current, reflecting the latest updates
-       in the library. If the context does not provide enough information, state
-       this in your answer and keep it short. If you are unsure what kind of
-       information the user needs, please ask follow-up questions.
-       """
 
 if config_env() == :prod do
   config :exmeralda, :admin_auth,

--- a/lib/exmeralda/chats/generation_environment.ex
+++ b/lib/exmeralda/chats/generation_environment.ex
@@ -5,10 +5,12 @@ defmodule Exmeralda.Chats.GenerationEnvironment do
   """
   use Exmeralda.Schema
   alias Exmeralda.LLM.{ModelConfigProvider, SystemPrompt}
+  alias Exmeralda.Topics.GenerationPrompt
 
   schema "generation_environments" do
     belongs_to :model_config_provider, ModelConfigProvider
     belongs_to :system_prompt, SystemPrompt
+    belongs_to :generation_prompt, GenerationPrompt
 
     timestamps()
   end

--- a/lib/exmeralda/chats/generation_environment.ex
+++ b/lib/exmeralda/chats/generation_environment.ex
@@ -4,10 +4,11 @@ defmodule Exmeralda.Chats.GenerationEnvironment do
   were used to generate a message.
   """
   use Exmeralda.Schema
-  alias Exmeralda.LLM.ModelConfigProvider
+  alias Exmeralda.LLM.{ModelConfigProvider, SystemPrompt}
 
   schema "generation_environments" do
     belongs_to :model_config_provider, ModelConfigProvider
+    belongs_to :system_prompt, SystemPrompt
 
     timestamps()
   end

--- a/lib/exmeralda/llm/system_prompt.ex
+++ b/lib/exmeralda/llm/system_prompt.ex
@@ -1,0 +1,12 @@
+defmodule Exmeralda.LLM.SystemPrompt do
+  @moduledoc """
+  System prompt that is passed to the LLM model.
+  """
+  use Exmeralda.Schema
+
+  schema "system_prompts" do
+    field :prompt, :string
+
+    timestamps()
+  end
+end

--- a/lib/exmeralda/topics/generation_prompt.ex
+++ b/lib/exmeralda/topics/generation_prompt.ex
@@ -1,0 +1,19 @@
+defmodule Exmeralda.Topics.GenerationPrompt do
+  @moduledoc """
+  Generation prompt that is passed to the RAG generation builder.
+
+  The `prompt` string can contain two placeholders:
+  - `%{query}`
+  - `%{context}`
+
+  The query being the question from the user, and the context is provided
+  by the ingestion's chunks.
+  """
+  use Exmeralda.Schema
+
+  schema "generation_prompts" do
+    field :prompt, :string
+
+    timestamps()
+  end
+end

--- a/priv/repo/migrations/20250827133706_create_system_prompts.exs
+++ b/priv/repo/migrations/20250827133706_create_system_prompts.exs
@@ -27,7 +27,7 @@ defmodule Exmeralda.Repo.Migrations.CreateSystemPrompts do
     execute(
       """
         INSERT INTO system_prompts (id, prompt, inserted_at, updated_at)
-        VALUES (gen_random_uuid(), '#{@default_prompt}', NOW(), NOW())
+        VALUES ('c8511eaf-d7e6-4fb6-b3f0-0ed8d8008d1b', '#{@default_prompt}', NOW(), NOW())
       """,
       ""
     )

--- a/priv/repo/migrations/20250827133706_create_system_prompts.exs
+++ b/priv/repo/migrations/20250827133706_create_system_prompts.exs
@@ -1,0 +1,57 @@
+defmodule Exmeralda.Repo.Migrations.CreateSystemPrompts do
+  use Ecto.Migration
+
+  @default_prompt """
+  You are an expert in Elixir programming with in-depth knowledge of Elixir.
+  Provide accurate information based on the provided context to assist Elixir
+  developers. Include code snippets and examples to illustrate your points.
+  Respond in a professional yet approachable manner.
+  Be concise for straightforward queries, but elaborate when necessary to
+  ensure clarity and understanding. Adapt your responses to the complexity of
+  the question. For basic usage, provide clear examples. For advanced topics,
+  offer detailed explanations and multiple solutions if applicable.
+  Include references to official documentation or reliable sources to support
+  your answers. Ensure information is current, reflecting the latest updates
+  in the library. If the context does not provide enough information, state
+  this in your answer and keep it short. If you are unsure what kind of
+  information the user needs, please ask follow-up questions.
+  """
+
+  def change do
+    create table(:system_prompts) do
+      add :prompt, :text, null: false
+
+      timestamps()
+    end
+
+    execute(
+      """
+        INSERT INTO system_prompts (id, prompt, inserted_at, updated_at)
+        VALUES (gen_random_uuid(), '#{@default_prompt}', NOW(), NOW())
+      """,
+      ""
+    )
+
+    alter table(:generation_environments) do
+      add :system_prompt_id, references(:system_prompts, on_delete: :restrict), null: true
+    end
+
+    drop unique_index(:generation_environments, [:model_config_provider_id])
+    create unique_index(:generation_environments, [:model_config_provider_id, :system_prompt_id])
+
+    execute(
+      """
+        UPDATE generation_environments
+        SET system_prompt_id = system_prompts.id
+        FROM system_prompts
+      """,
+      ""
+    )
+
+    alter table(:generation_environments) do
+      modify :system_prompt_id, references(:system_prompts, on_delete: :restrict),
+        null: false,
+        from: references(:system_prompts, on_delete: :restrict)
+    end
+  end
+end

--- a/priv/repo/migrations/20250827142531_create_generation_prompts.exs
+++ b/priv/repo/migrations/20250827142531_create_generation_prompts.exs
@@ -1,0 +1,60 @@
+defmodule Exmeralda.Repo.Migrations.CreateGenerationPrompts do
+  use Ecto.Migration
+
+  @default_prompt """
+  Context information is below.
+  ---------------------
+  %{context}
+  ---------------------
+  Given the context information and no prior knowledge, answer the query.
+  Query: %{query}
+  Answer:
+  """
+
+  def change do
+    create table(:generation_prompts) do
+      add :prompt, :text, null: false
+
+      timestamps()
+    end
+
+    execute(
+      """
+        INSERT INTO generation_prompts (id, prompt, inserted_at, updated_at)
+        VALUES (gen_random_uuid(), '#{@default_prompt}', NOW(), NOW())
+      """,
+      ""
+    )
+
+    alter table(:generation_environments) do
+      add :generation_prompt_id, references(:generation_prompts, on_delete: :restrict), null: true
+    end
+
+    drop unique_index(:generation_environments, [:model_config_provider_id, :system_prompt_id])
+
+    create unique_index(
+             :generation_environments,
+             [
+               :model_config_provider_id,
+               :system_prompt_id,
+               :generation_prompt_id
+             ],
+             name: "generation_environments_unique"
+           )
+
+    execute(
+      """
+        UPDATE generation_environments
+        SET generation_prompt_id = generation_prompts.id
+        FROM generation_prompts
+      """,
+      ""
+    )
+
+    alter table(:generation_environments) do
+      modify :generation_prompt_id, references(:generation_prompts, on_delete: :restrict),
+        null: false,
+        from: references(:generation_prompts, on_delete: :restrict)
+    end
+  end
+end

--- a/priv/repo/migrations/20250827142531_create_generation_prompts.exs
+++ b/priv/repo/migrations/20250827142531_create_generation_prompts.exs
@@ -21,7 +21,7 @@ defmodule Exmeralda.Repo.Migrations.CreateGenerationPrompts do
     execute(
       """
         INSERT INTO generation_prompts (id, prompt, inserted_at, updated_at)
-        VALUES (gen_random_uuid(), '#{@default_prompt}', NOW(), NOW())
+        VALUES ('56220820-142e-4811-9155-c4574f9b508e', '#{@default_prompt}', NOW(), NOW())
       """,
       ""
     )

--- a/test/exmeralda/chats/generation_environment_test.exs
+++ b/test/exmeralda/chats/generation_environment_test.exs
@@ -4,12 +4,20 @@ defmodule Exmeralda.Chats.GenerationEnvironmentTest do
   describe "table" do
     test "unique by model_config_provider" do
       model_config_provider = insert(:model_config_provider)
-      insert(:generation_environment, model_config_provider: model_config_provider)
+      system_prompt = insert(:system_prompt)
+
+      insert(:generation_environment,
+        model_config_provider: model_config_provider,
+        system_prompt: system_prompt
+      )
 
       assert_raise Ecto.ConstraintError,
-                   ~r/generation_environments_model_config_provider_id_index/,
+                   ~r/generation_environments_model_config_provider_id_system_prompt/,
                    fn ->
-                     insert(:generation_environment, model_config_provider: model_config_provider)
+                     insert(:generation_environment,
+                       model_config_provider: model_config_provider,
+                       system_prompt: system_prompt
+                     )
                    end
     end
   end

--- a/test/exmeralda/chats/generation_environment_test.exs
+++ b/test/exmeralda/chats/generation_environment_test.exs
@@ -2,21 +2,24 @@ defmodule Exmeralda.Chats.GenerationEnvironmentTest do
   use Exmeralda.DataCase
 
   describe "table" do
-    test "unique by model_config_provider" do
+    test "unique by model_config_provider, system prompt and generation prompt" do
       model_config_provider = insert(:model_config_provider)
       system_prompt = insert(:system_prompt)
+      generation_prompt = insert(:generation_prompt)
 
       insert(:generation_environment,
         model_config_provider: model_config_provider,
-        system_prompt: system_prompt
+        system_prompt: system_prompt,
+        generation_prompt: generation_prompt
       )
 
       assert_raise Ecto.ConstraintError,
-                   ~r/generation_environments_model_config_provider_id_system_prompt/,
+                   ~r/generation_environments_unique/,
                    fn ->
                      insert(:generation_environment,
                        model_config_provider: model_config_provider,
-                       system_prompt: system_prompt
+                       system_prompt: system_prompt,
+                       generation_prompt: generation_prompt
                      )
                    end
     end

--- a/test/exmeralda/chats/llm_test.exs
+++ b/test/exmeralda/chats/llm_test.exs
@@ -38,10 +38,7 @@ defmodule Exmeralda.Chats.LLMTest do
       model_config_provider =
         insert(:model_config_provider, model_config: model_config, provider: provider)
 
-      generation_environment =
-        insert(:generation_environment, model_config_provider: model_config_provider)
-
-      assert LLM.llm(generation_environment.id) == %Exmeralda.LLM.Fake{
+      assert LLM.llm(model_config_provider) == %Exmeralda.LLM.Fake{
                name: "MockChatModel",
                version: "1.0",
                callbacks: []
@@ -50,7 +47,7 @@ defmodule Exmeralda.Chats.LLMTest do
 
     test "with an ollama provider" do
       provider = insert(:provider, type: :ollama)
-      model_config = insert(:model_config, name: "fake-model", config: %{stream: true})
+      model_config = insert(:model_config, name: "fake-model", config: %{"stream" => true})
 
       model_config_provider =
         insert(:model_config_provider,
@@ -59,11 +56,8 @@ defmodule Exmeralda.Chats.LLMTest do
           name: "Fake-Model"
         )
 
-      generation_environment =
-        insert(:generation_environment, model_config_provider: model_config_provider)
-
       assert %LangChain.ChatModels.ChatOllamaAI{model: "Fake-Model", stream: true} =
-               LLM.llm(generation_environment.id)
+               LLM.llm(model_config_provider)
     end
 
     test "with an openai provider" do
@@ -71,10 +65,10 @@ defmodule Exmeralda.Chats.LLMTest do
         insert(:provider,
           type: :openai,
           name: "foo_ai",
-          config: %{endpoint: "https://example.com/v1/chat/completions"}
+          config: %{"endpoint" => "https://example.com/v1/chat/completions"}
         )
 
-      model_config = insert(:model_config, name: "qwen25", config: %{stream: true})
+      model_config = insert(:model_config, name: "qwen25", config: %{"stream" => true})
 
       model_config_provider =
         insert(:model_config_provider,
@@ -83,15 +77,12 @@ defmodule Exmeralda.Chats.LLMTest do
           name: "Qwen/Qwen25"
         )
 
-      generation_environment =
-        insert(:generation_environment, model_config_provider: model_config_provider)
-
       assert %LangChain.ChatModels.ChatOpenAI{
                model: "Qwen/Qwen25",
                stream: true,
                endpoint: "https://example.com/v1/chat/completions",
                api_key: "abcde"
-             } = LLM.llm(generation_environment.id)
+             } = LLM.llm(model_config_provider)
     end
   end
 end

--- a/test/exmeralda/chats_test.exs
+++ b/test/exmeralda/chats_test.exs
@@ -150,7 +150,14 @@ defmodule Exmeralda.ChatsTest do
           id: test_model_config_provider_id()
         )
 
-      %{library: library, ingestion: ingestion, model_config_provider: model_config_provider}
+      system_prompt = insert(:system_prompt, id: test_system_prompt_id())
+
+      %{
+        library: library,
+        ingestion: ingestion,
+        model_config_provider: model_config_provider,
+        system_prompt: system_prompt
+      }
     end
 
     test "errors with a changeset with invalid attrs", %{user: user} do
@@ -190,7 +197,8 @@ defmodule Exmeralda.ChatsTest do
       user: user,
       library: library,
       ingestion: ingestion,
-      model_config_provider: model_config_provider
+      model_config_provider: model_config_provider,
+      system_prompt: system_prompt
     } do
       generation_environment =
         assert_count_differences(
@@ -210,6 +218,7 @@ defmodule Exmeralda.ChatsTest do
 
             [generation_environment] = Repo.all(GenerationEnvironment)
             assert generation_environment.model_config_provider_id == model_config_provider.id
+            assert generation_environment.system_prompt_id == system_prompt.id
 
             # messages are sorted asc: :index on sessions
             [message, assistant_message] = session.messages
@@ -278,7 +287,13 @@ defmodule Exmeralda.ChatsTest do
           id: test_model_config_provider_id()
         )
 
-      %{session: session, model_config_provider: model_config_provider}
+      system_prompt = insert(:system_prompt, id: test_system_prompt_id())
+
+      %{
+        session: session,
+        model_config_provider: model_config_provider,
+        system_prompt: system_prompt
+      }
     end
 
     test "errors with a changeset for invalid attrs", %{session: session} do
@@ -309,7 +324,8 @@ defmodule Exmeralda.ChatsTest do
 
     test "creates a message and upserts a generation environment", %{
       session: session,
-      model_config_provider: model_config_provider
+      model_config_provider: model_config_provider,
+      system_prompt: system_prompt
     } do
       assert Repo.aggregate(GenerationEnvironment, :count) == 2
 
@@ -325,6 +341,7 @@ defmodule Exmeralda.ChatsTest do
             Repo.get_by(GenerationEnvironment, model_config_provider_id: model_config_provider.id)
 
           assert generation_environment.model_config_provider_id == model_config_provider.id
+          assert generation_environment.system_prompt_id == system_prompt.id
 
           assert message.index == 2
           assert message.role == :user

--- a/test/exmeralda/chats_test.exs
+++ b/test/exmeralda/chats_test.exs
@@ -151,12 +151,14 @@ defmodule Exmeralda.ChatsTest do
         )
 
       system_prompt = insert(:system_prompt, id: test_system_prompt_id())
+      generation_prompt = insert(:generation_prompt, id: test_generation_prompt_id())
 
       %{
         library: library,
         ingestion: ingestion,
         model_config_provider: model_config_provider,
-        system_prompt: system_prompt
+        system_prompt: system_prompt,
+        generation_prompt: generation_prompt
       }
     end
 
@@ -198,7 +200,8 @@ defmodule Exmeralda.ChatsTest do
       library: library,
       ingestion: ingestion,
       model_config_provider: model_config_provider,
-      system_prompt: system_prompt
+      system_prompt: system_prompt,
+      generation_prompt: generation_prompt
     } do
       generation_environment =
         assert_count_differences(
@@ -219,6 +222,7 @@ defmodule Exmeralda.ChatsTest do
             [generation_environment] = Repo.all(GenerationEnvironment)
             assert generation_environment.model_config_provider_id == model_config_provider.id
             assert generation_environment.system_prompt_id == system_prompt.id
+            assert generation_environment.generation_prompt_id == generation_prompt.id
 
             # messages are sorted asc: :index on sessions
             [message, assistant_message] = session.messages
@@ -288,11 +292,13 @@ defmodule Exmeralda.ChatsTest do
         )
 
       system_prompt = insert(:system_prompt, id: test_system_prompt_id())
+      generation_prompt = insert(:generation_prompt, id: test_generation_prompt_id())
 
       %{
         session: session,
         model_config_provider: model_config_provider,
-        system_prompt: system_prompt
+        system_prompt: system_prompt,
+        generation_prompt: generation_prompt
       }
     end
 
@@ -325,7 +331,8 @@ defmodule Exmeralda.ChatsTest do
     test "creates a message and upserts a generation environment", %{
       session: session,
       model_config_provider: model_config_provider,
-      system_prompt: system_prompt
+      system_prompt: system_prompt,
+      generation_prompt: generation_prompt
     } do
       assert Repo.aggregate(GenerationEnvironment, :count) == 2
 
@@ -342,6 +349,7 @@ defmodule Exmeralda.ChatsTest do
 
           assert generation_environment.model_config_provider_id == model_config_provider.id
           assert generation_environment.system_prompt_id == system_prompt.id
+          assert generation_environment.generation_prompt_id == generation_prompt.id
 
           assert message.index == 2
           assert message.role == :user

--- a/test/exmeralda/topics/rag_test.exs
+++ b/test/exmeralda/topics/rag_test.exs
@@ -1,0 +1,59 @@
+defmodule Exmeralda.Topics.RagTest do
+  use Exmeralda.DataCase
+  import Exmeralda.Topics.Rag
+  alias Exmeralda.Topics.Chunk
+
+  describe "build_generation/3" do
+    test "raises if the generation environment is not found" do
+      message = build(:message, generation_environment_id: uuid())
+
+      assert_raise(Ecto.NoResultsError, fn ->
+        build_generation(from(c in Chunk), message)
+      end)
+    end
+
+    test "returns a generation and result" do
+      library = insert(:library)
+      ingestion = insert(:ingestion, library: library)
+
+      chunk =
+        insert(:chunk,
+          ingestion: ingestion,
+          library: library,
+          content: "The cookie jar does not exist"
+        )
+
+      generation_prompt = insert(:generation_prompt)
+
+      generation_environment =
+        insert(:generation_environment, generation_prompt: generation_prompt)
+
+      message =
+        insert(:message,
+          generation_environment: generation_environment,
+          content: "Where is the cookie jar?"
+        )
+
+      assert {[%Chunk{} = result], %Rag.Generation{} = generation} =
+               build_generation(from(c in Chunk), message)
+
+      assert result.id == chunk.id
+
+      assert generation.query == "Where is the cookie jar?"
+      assert generation.context == "The cookie jar does not exist"
+
+      assert generation.prompt == """
+             Context information is below.
+             ---------------------
+             The cookie jar does not exist
+             ---------------------
+             Given the context information and no prior knowledge, answer the query.
+             Query: Where is the cookie jar?
+             Answer:
+             """
+
+      assert %{fulltext_results: [%Chunk{}], semantic_results: [%Chunk{}], rrf_result: [%Chunk{}]} =
+               generation.retrieval_results
+    end
+  end
+end

--- a/test/exmeralda_web/live/chat_live_test.exs
+++ b/test/exmeralda_web/live/chat_live_test.exs
@@ -42,6 +42,7 @@ defmodule ExmeraldaWeb.ChatLiveTest do
     )
 
     insert(:system_prompt, id: test_system_prompt_id())
+    insert(:generation_prompt, id: test_generation_prompt_id())
 
     :ok
   end

--- a/test/exmeralda_web/live/chat_live_test.exs
+++ b/test/exmeralda_web/live/chat_live_test.exs
@@ -41,6 +41,8 @@ defmodule ExmeraldaWeb.ChatLiveTest do
       id: test_model_config_provider_id()
     )
 
+    insert(:system_prompt, id: test_system_prompt_id())
+
     :ok
   end
 

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -61,6 +61,7 @@ defmodule ExmeraldaWeb.ConnCase do
     end
   end
 
-  def test_system_prompt_id, do: "96123e4b-7d0a-4e14-82d4-63d68562e8f1"
   def test_model_config_provider_id, do: "9a21bfd3-cb0a-433c-a9b3-826143782c81"
+  def test_system_prompt_id, do: "96123e4b-7d0a-4e14-82d4-63d68562e8f1"
+  def test_generation_prompt_id, do: "a6dd3ab3-d57e-43d9-a39a-d1ce58a43cc0"
 end

--- a/test/support/conn_case.ex
+++ b/test/support/conn_case.ex
@@ -61,5 +61,6 @@ defmodule ExmeraldaWeb.ConnCase do
     end
   end
 
+  def test_system_prompt_id, do: "96123e4b-7d0a-4e14-82d4-63d68562e8f1"
   def test_model_config_provider_id, do: "9a21bfd3-cb0a-433c-a9b3-826143782c81"
 end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -74,4 +74,5 @@ defmodule Exmeralda.DataCase do
   end
 
   def test_model_config_provider_id, do: "9a21bfd3-cb0a-433c-a9b3-826143782c81"
+  def test_system_prompt_id, do: "96123e4b-7d0a-4e14-82d4-63d68562e8f1"
 end

--- a/test/support/data_case.ex
+++ b/test/support/data_case.ex
@@ -75,4 +75,5 @@ defmodule Exmeralda.DataCase do
 
   def test_model_config_provider_id, do: "9a21bfd3-cb0a-433c-a9b3-826143782c81"
   def test_system_prompt_id, do: "96123e4b-7d0a-4e14-82d4-63d68562e8f1"
+  def test_generation_prompt_id, do: "a6dd3ab3-d57e-43d9-a39a-d1ce58a43cc0"
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -121,13 +121,28 @@ defmodule Exmeralda.Factory do
   def generation_environment_factory do
     %Exmeralda.Chats.GenerationEnvironment{
       model_config_provider: build(:model_config_provider),
-      system_prompt: build(:system_prompt)
+      system_prompt: build(:system_prompt),
+      generation_prompt: build(:generation_prompt)
     }
   end
 
   def system_prompt_factory do
     %Exmeralda.LLM.SystemPrompt{
       prompt: "You are an expert in Elixir programming with in-depth knowledge of Elixir."
+    }
+  end
+
+  def generation_prompt_factory do
+    %Exmeralda.Topics.GenerationPrompt{
+      prompt: """
+      Context information is below.
+      ---------------------
+      %{context}
+      ---------------------
+      Given the context information and no prior knowledge, answer the query.
+      Query: %{query}
+      Answer:
+      """
     }
   end
 end

--- a/test/support/factory.ex
+++ b/test/support/factory.ex
@@ -120,7 +120,14 @@ defmodule Exmeralda.Factory do
 
   def generation_environment_factory do
     %Exmeralda.Chats.GenerationEnvironment{
-      model_config_provider: build(:model_config_provider)
+      model_config_provider: build(:model_config_provider),
+      system_prompt: build(:system_prompt)
+    }
+  end
+
+  def system_prompt_factory do
+    %Exmeralda.LLM.SystemPrompt{
+      prompt: "You are an expert in Elixir programming with in-depth knowledge of Elixir."
     }
   end
 end

--- a/test/support/seeds.ex
+++ b/test/support/seeds.ex
@@ -1,8 +1,30 @@
 defmodule Exmeralda.Seeds do
   alias Exmeralda.Repo
 
+  @default_prompt """
+    You are an expert in Elixir programming with in-depth knowledge of Elixir.
+    Provide accurate information based on the provided context to assist Elixir
+    developers. Include code snippets and examples to illustrate your points.
+    Respond in a professional yet approachable manner.
+    Be concise for straightforward queries, but elaborate when necessary to
+    ensure clarity and understanding. Adapt your responses to the complexity of
+    the question. For basic usage, provide clear examples. For advanced topics,
+    offer detailed explanations and multiple solutions if applicable.
+    Include references to official documentation or reliable sources to support
+    your answers. Ensure information is current, reflecting the latest updates
+    in the library. If the context does not provide enough information, state
+    this in your answer and keep it short. If you are unsure what kind of
+    information the user needs, please ask follow-up questions.
+  """
+
   def run do
     if Mix.env() == :dev do
+      _system_prompt =
+        insert_idempotently(%Exmeralda.LLM.SystemPrompt{
+          id: "c49195b4-daca-42af-835d-bdb928986d5c",
+          prompt: @default_prompt
+        })
+
       mock_provider =
         insert_idempotently(%Exmeralda.LLM.Provider{
           id: "62b47ee3-17ec-4c41-ac5e-3d8d6c0ac83d",

--- a/test/support/seeds.ex
+++ b/test/support/seeds.ex
@@ -1,7 +1,7 @@
 defmodule Exmeralda.Seeds do
   alias Exmeralda.Repo
 
-  @default_prompt """
+  @default_system_prompt """
     You are an expert in Elixir programming with in-depth knowledge of Elixir.
     Provide accurate information based on the provided context to assist Elixir
     developers. Include code snippets and examples to illustrate your points.
@@ -17,12 +17,28 @@ defmodule Exmeralda.Seeds do
     information the user needs, please ask follow-up questions.
   """
 
+  @default_generation_prompt """
+  Context information is below.
+  ---------------------
+  %{context}
+  ---------------------
+  Given the context information and no prior knowledge, answer the query.
+  Query: %{query}
+  Answer:
+  """
+
   def run do
     if Mix.env() == :dev do
       _system_prompt =
         insert_idempotently(%Exmeralda.LLM.SystemPrompt{
           id: "c49195b4-daca-42af-835d-bdb928986d5c",
-          prompt: @default_prompt
+          prompt: @default_system_prompt
+        })
+
+      _generation_prompt =
+        insert_idempotently(%Exmeralda.Topics.GenerationPrompt{
+          id: "3ef5b20b-bb71-467d-8364-898df9926a95",
+          prompt: @default_generation_prompt
         })
 
       mock_provider =


### PR DESCRIPTION
In order to allow developers and testers to try the chatbot with different setup, we introduce tables for the system (llm) and generation (rag) prompts. 

This way, a message in the chat can be linked to a system and generation prompt in a deterministic way. This will enable us to make analysis on the prompts and the answers given by the chatbot. 

For now there is only one system and one generation prompt, and since they never changed, I created them in the migration. 