### PR TITLE
[EX-126] Fix fulltext search on Exmeralda

### DIFF
--- a/test/exmeralda/topics/rag/evaluation_test.exs
+++ b/test/exmeralda/topics/rag/evaluation_test.exs
@@ -259,5 +259,10 @@ defmodule Exmeralda.Topics.Rag.EvaluationTest do
       assert result =~
                "ingestion_id,generation_environment_id,chunk_id,question,first_hit_correct?,first_hit_id,total_chunks_found,chunk_was_found?,chunk_rank"
     end
+
+    test "accepts an aggregate optional parameter" do
+      assert %{question_count: 2, first_hit_ratio: _, found_chunk_ratio: _} =
+               Evaluation.batch_evaluation(@fixture_file, aggregate: true)
+    end
   end
 end

--- a/test/exmeralda/topics/rag_test.exs
+++ b/test/exmeralda/topics/rag_test.exs
@@ -16,7 +16,7 @@ defmodule Exmeralda.Topics.RagTest do
       library = insert(:library)
       ingestion = insert(:ingestion, library: library)
 
-      chunk =
+      %{id: chunk_id} =
         insert(:chunk,
           ingestion: ingestion,
           library: library,
@@ -34,10 +34,8 @@ defmodule Exmeralda.Topics.RagTest do
           content: "Where is the cookie jar?"
         )
 
-      assert {[%Chunk{} = result], %Rag.Generation{} = generation} =
+      assert {[%{id: ^chunk_id}], %Rag.Generation{} = generation} =
                build_generation(from(c in Chunk), message)
-
-      assert result.id == chunk.id
 
       assert generation.query == "Where is the cookie jar?"
       assert generation.context == "The cookie jar does not exist"
@@ -52,7 +50,11 @@ defmodule Exmeralda.Topics.RagTest do
              Answer:
              """
 
-      assert %{fulltext_results: [%Chunk{}], semantic_results: [%Chunk{}], rrf_result: [%Chunk{}]} =
+      assert %{
+               fulltext_results: [%{id: ^chunk_id}],
+               semantic_results: [%{id: ^chunk_id}],
+               rrf_result: [%{id: ^chunk_id}]
+             } =
                generation.retrieval_results
     end
   end


### PR DESCRIPTION
This PR:

- adds an aggregate option to `batch_evaluation`
- updates the fulltext search function to use `ts_rank`

I generated 50 questions about BitcrowdEcto and ran some evaluations:

| search strategy | results |
| -- | -- |
| only old fulltext search implementation | `found_chunk_ratio: 0.0, first_hit_ratio: 0.0` |
| full strategy with old fulltext search implementation | `found_chunk_ratio: 0.14, first_hit_ratio: 0.04` |
| only new fulltext search implementation | `found_chunk_ratio: 0.16, first_hit_ratio: 0.02` |
| full strategy with new fulltext search implementation | `found_chunk_ratio: 0.24, first_hit_ratio: 0.08` |
| semantic search only | `found_chunk_ratio: 0.14, first_hit_ratio: 0.06` |

The full text search indeed improved with the changes 🎉 

The results are overall still not super great though. I think there are multiple things we could try to get to better results:
- exclude HTML files from ingestion (if that is an option). This would remove chunks with "duplicate" content (once from the original ex file and once from the generated HTML)
- improve question generation (maybe try to refine the prompt? maybe make the questions try to cover as much content as possible from the chunk, so that it is more likely that the chunk will be the first find)

Also I think we could make the evaluation function even more fancy, by adding an option to evaluate all retrieval results (semantic, fulltext, ranked).

I think I would move those ideas ☝️ into a seperate ticket though.


https://bitcrowd.atlassian.net/browse/EX-126