### PR TITLE
Update migrations to not use Mix

### DIFF
--- a/lib/exmeralda/migration_helper.ex
+++ b/lib/exmeralda/migration_helper.ex
@@ -1,0 +1,10 @@
+defmodule Exmeralda.MigrationHelper do
+  def env do
+    compile_env = if Code.ensure_loaded?(Mix), do: Mix.env(), else: nil
+
+    case System.get_env("MIX_ENV") do
+      nil -> compile_env || :prod
+      env -> String.to_atom(env)
+    end
+  end
+end

--- a/priv/repo/migrations/20250827133706_create_system_prompts.exs
+++ b/priv/repo/migrations/20250827133706_create_system_prompts.exs
@@ -24,7 +24,7 @@ defmodule Exmeralda.Repo.Migrations.CreateSystemPrompts do
       timestamps()
     end
 
-    unless Mix.env() == :test do
+    unless Exmeralda.MigrationHelper.env() == :test do
       execute(
         """
           INSERT INTO system_prompts (id, prompt, inserted_at, updated_at)

--- a/priv/repo/migrations/20250827142531_create_generation_prompts.exs
+++ b/priv/repo/migrations/20250827142531_create_generation_prompts.exs
@@ -18,7 +18,7 @@ defmodule Exmeralda.Repo.Migrations.CreateGenerationPrompts do
       timestamps()
     end
 
-    unless Mix.env() == :test do
+    unless Exmeralda.MigrationHelper.env() == :test do
       execute(
         """
           INSERT INTO generation_prompts (id, prompt, inserted_at, updated_at)

--- a/priv/repo/migrations/20251209091924_update_production_model.exs
+++ b/priv/repo/migrations/20251209091924_update_production_model.exs
@@ -2,7 +2,7 @@ defmodule Exmeralda.Repo.Migrations.UpdateProductionModel do
   use Ecto.Migration
 
   def change do
-    unless Mix.env() == :test do
+    unless Exmeralda.MigrationHelper.env() == :test do
       execute(
         """
         INSERT INTO model_configs (id, name, config, inserted_at, updated_at)


### PR DESCRIPTION
Mix is not available at compile time. So migrations checking the env via
Mix.env() don't work for our releases to Fly.io.
